### PR TITLE
Make TopoViewer the default graph action

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
       {
         "command": "containerlab.lab.graph.topoViewer",
         "title": "Graph Lab (TopoViewer)",
+        "icon": "$(graph-line)",
         "category": "Containerlab"
       },
       {
@@ -295,7 +296,7 @@
       "editor/title": [
         {
           "when": "resourceFilename =~ /\\.clab\\.(yml|yaml)$/",
-          "command": "containerlab.lab.graph",
+          "command": "containerlab.lab.graph.topoViewer",
           "group": "navigation@0"
         }
       ],
@@ -329,6 +330,58 @@
           "when": "resourceFilename =~ /\\.clab\\.(yml|yaml)$/",
           "command": "containerlab.lab.destroy.cleanup",
           "group": "navigation@6"
+        }
+      ],
+      "editor/title/context": [
+        {
+          "when": "resourceFilename =~ /\\.clab\\.(yml|yaml)$/",
+          "command": "containerlab.lab.deploy",
+          "group": "clabLabActions@1"
+        },
+        {
+          "when": "resourceFilename =~ /\\.clab\\.(yml|yaml)$/",
+          "command": "containerlab.lab.deploy.cleanup",
+          "group": "clabLabActions@2"
+        },
+        {
+          "when": "resourceFilename =~ /\\.clab\\.(yml|yaml)$/",
+          "command": "containerlab.lab.redeploy",
+          "group": "clabLabActions@3"
+        },
+        {
+          "when": "resourceFilename =~ /\\.clab\\.(yml|yaml)$/",
+          "command": "containerlab.lab.redeploy.cleanup",
+          "group": "clabLabActions@4"
+        },
+        {
+          "when": "resourceFilename =~ /\\.clab\\.(yml|yaml)$/",
+          "command": "containerlab.lab.destroy",
+          "group": "clabLabActions@5"
+        },
+        {
+          "when": "resourceFilename =~ /\\.clab\\.(yml|yaml)$/",
+          "command": "containerlab.lab.destroy.cleanup",
+          "group": "clabLabActions@6"
+        },
+        {
+          "command": "containerlab.lab.graph",
+          "when": "resourceFilename =~ /\\.clab\\.(yml|yaml)$/",
+          "group": "graph@0"
+        },
+        {
+          "command": "containerlab.lab.graph.drawio",
+          "when": "resourceFilename =~ /\\.clab\\.(yml|yaml)$/",
+          "group": "graph@1"
+        },
+        {
+          "command": "containerlab.lab.graph.drawio.interactive",
+          "when": "resourceFilename =~ /\\.clab\\.(yml|yaml)$/",
+          "group": "graph@2"
+        },
+        {
+          "command": "containerlab.lab.graph.topoViewer",
+          "when": "resourceFilename =~ /\\.clab\\.(yml|yaml)$/",
+          "group": "graph@3"
         }
       ],
       "view/item/context": [
@@ -620,7 +673,7 @@
       {
         "key": "ctrl+alt+g",
         "mac": "cmd+alt+g",
-        "command": "containerlab.lab.graph"
+        "command": "containerlab.lab.graph.topoViewer"
       }
     ],
     "configuration": {

--- a/src/commands/graph.ts
+++ b/src/commands/graph.ts
@@ -86,8 +86,6 @@ export async function graphTopoviewer(node: ClabLabTreeNode, context: vscode.Ext
 
   let labPath: string;
 
-  console.error(node)
-
   if (!(node instanceof ClabLabTreeNode) || !node) {
     const editor = vscode.window.activeTextEditor;
     if (!editor) {

--- a/src/commands/graph.ts
+++ b/src/commands/graph.ts
@@ -81,19 +81,34 @@ export async function graphTopoviewer(node: ClabLabTreeNode, context: vscode.Ext
   currentTopoViewer = viewer;
 
   // do the same logic as before...
-  const provider = new ClabTreeDataProvider(context);5
+  const provider = new ClabTreeDataProvider(context);
   const clabTreeDataToTopoviewer = await provider.discoverInspectLabs();
 
-  // if node, if labPath, etc...
-  const yamlFilePath = node.labPath.absolute;
-  if (!yamlFilePath) {
-    vscode.window.showErrorMessage('No labPath to redeploy.');
-    return;
+  let labPath: string;
+
+  console.error(node)
+
+  if (!(node instanceof ClabLabTreeNode) || !node) {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+      vscode.window.showErrorMessage(
+        'No lab node or topology file selected'
+      );
+      return;
+    }
+    labPath = editor.document.uri.fsPath;
+  }
+  else {
+    labPath = node.labPath.absolute;
+    if (!labPath) {
+      vscode.window.showErrorMessage('Lab path not found');
+      return;
+    }
   }
 
   try {
     // 3) call openViewer, which returns (panel | undefined).
-    currentTopoViewerPanel = await viewer.openViewer(yamlFilePath, clabTreeDataToTopoviewer);
+    currentTopoViewerPanel = await viewer.openViewer(labPath, clabTreeDataToTopoviewer);
 
     // await viewer.openViewer(yamlFilePath, clabTreeDataToTopoviewer);
     // currentTopoViewerPanel = viewer.currentTopoViewerPanel


### PR DESCRIPTION
PR does a few things:

- Make TopoViewer the default graph action.
- Add commands to the editor tab context menu (right click on the open editor tab).
- Add TopoViewer support for getting labPath via the open editor filepath.

I don't know what's going on with the branches, so the target branch for this is `main`. Let me know if any rebasing needs to be done to get it in `dev`.

Give it a test please @FloSch62 @asadarafat. Thanks

![image](https://github.com/user-attachments/assets/1133d155-cdfe-4609-a4f8-1e49c9d843d0)
