### PR TITLE
Fix, do not await user decision

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "icon": "resources/containerlab.png",
   "description": "Manages containerlab topologies in VS Code",
   "author": "SRL Labs",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "homepage": "https://containerlab.dev/manual/vsc-extension/",
   "engines": {
     "vscode": "^1.70.0"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,7 +42,9 @@ export async function activate(context: vscode.ExtensionContext) {
   }
 
   // 2) If installed, check for updates
-  await checkAndUpdateClabIfNeeded(outputChannel);
+  checkAndUpdateClabIfNeeded(outputChannel, context).catch(err => {
+    outputChannel.appendLine(`[ERROR] Update check error: ${err.message}`);
+  });
 
   // Show welcome page
   const welcomePage = new WelcomePage(context);


### PR DESCRIPTION
This fixes a blocking extension activation. When a user did not made a decision to update or to skip the update, the extension was not activated.