### PR TITLE
Support of the new json format of containerlab 0.68.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [0.11.2] - 2025-04-10
+* Fix: Welcomepage
+* Patch: Support of containerlab 0.68.0
+
 ## [0.11.1] - 2025-04-10
 * Fix: Update terminal name for telnet
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "icon": "resources/containerlab.png",
   "description": "Manages containerlab topologies in VS Code",
   "author": "SRL Labs",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "homepage": "https://containerlab.dev/manual/vsc-extension/",
   "engines": {
     "vscode": "^1.70.0"

--- a/src/clabTreeDataProvider.ts
+++ b/src/clabTreeDataProvider.ts
@@ -95,16 +95,18 @@ export class ClabContainerTreeNode extends vscode.TreeItem {
  * clab inspect data (in JSON format).
  */
 interface ClabJSON {
-  container_id: string,
-  image: string,
-  ipv4_address: string,
-  ipv6_address: string,
-  kind: string,
-  lab_name: string,
-  labPath: string,
-  name: string,
-  owner: string,
-  state: string,
+  container_id: string;
+  image: string;
+  ipv4_address: string;
+  ipv6_address: string;
+  kind: string;
+  lab_name: string;
+  labPath: string;      // Path as provided by containerlab (might be relative)
+  absLabPath?: string;  // Absolute path (present in newer versions >= 0.68.0)
+  name: string;
+  owner: string;
+  state: string;
+  status?: string; // Also add the optional status field from the new format
 }
 
 /**
@@ -218,8 +220,10 @@ export class ClabTreeDataProvider implements vscode.TreeDataProvider<ClabLabTree
     if (!element) { return this.discoverLabs(); }
     // Find containers belonging to a lab
     if (element instanceof ClabLabTreeNode) { return element.containers; }
-    // For containers or interfaces we do not show further children
+    // Find interfaces belonging to a container
     if (element instanceof ClabContainerTreeNode) {
+      // Ensure interfaces are fetched/updated if needed (or rely on existing cache logic)
+      // The existing discoverContainerInterfaces logic with caching should handle this.
       return element.interfaces;
     }
 
@@ -232,7 +236,21 @@ export class ClabTreeDataProvider implements vscode.TreeDataProvider<ClabLabTree
     const localLabs = await this.discoverLocalLabs();     // Undeployed topologies
     const globalLabs = await this.discoverInspectLabs();  // Deployed labs from `clab inspect -a`
 
-    if (!localLabs && !globalLabs) {
+    // --- Combine local and global labs ---
+    // Initialize with global labs (deployed)
+    const labs: Record<string, ClabLabTreeNode> = globalLabs ? { ...globalLabs } : {};
+
+    // Add local labs (undeployed) if they don't already exist as deployed
+    if (localLabs) {
+      for (const labPath in localLabs) {
+        if (!labs.hasOwnProperty(labPath)) {
+          labs[labPath] = localLabs[labPath];
+        }
+      }
+    }
+
+    // Handle case where no labs are found at all
+    if (Object.keys(labs).length === 0) {
       console.error("[discovery]:\tNo labs found");
       return [
         new ClabLabTreeNode(
@@ -241,31 +259,20 @@ export class ClabTreeDataProvider implements vscode.TreeDataProvider<ClabLabTree
           { absolute: "", relative: "" }
         )
       ];
-    } else if (!globalLabs) {
-      console.error("[discovery]:\tNo inspected labs found");
-      return Object.values(localLabs!).sort((a, b) => a.labPath.absolute.localeCompare(b.labPath.absolute));
-    } else if (!localLabs) {
-      console.error("[discovery]:\tNo local labs found");
-      return Object.values(globalLabs).sort((a, b) => a.labPath.absolute.localeCompare(b.labPath.absolute));
-    }
-
-    // Merge them into a single dictionary
-    const labs: Record<string, ClabLabTreeNode> = { ...globalLabs };
-    for (const labPath in localLabs) {
-      if (!labs.hasOwnProperty(labPath)) {
-        labs[labPath] = localLabs[labPath];
-      }
     }
 
     // Convert the dict to an array and sort by:
     // 1. Deployed labs first
     // 2. Then by absolute path
     const sortedLabs = Object.values(labs).sort((a, b) => {
-      if (a.contextValue === "containerlabLabDeployed" && b.contextValue === "containerlabLabUndeployed") {
-        return -1;
+      const isADeployed = a.contextValue === "containerlabLabDeployed";
+      const isBDeployed = b.contextValue === "containerlabLabDeployed";
+
+      if (isADeployed && !isBDeployed) {
+        return -1; // a (deployed) comes before b (undeployed)
       }
-      if (a.contextValue === "containerlabLabUndeployed" && b.contextValue === "containerlabLabDeployed") {
-        return 1;
+      if (!isADeployed && isBDeployed) {
+        return 1; // b (deployed) comes before a (undeployed)
       }
       // If same deployment status, sort by path
       return a.labPath.absolute.localeCompare(b.labPath.absolute);
@@ -331,57 +338,95 @@ export class ClabTreeDataProvider implements vscode.TreeDataProvider<ClabLabTree
       return this.labsCache.inspect.data;
     }
 
-    const inspectData = await this.getInspectData();
-    if (!inspectData) {
+    const inspectData = await this.getInspectData(); // Fetches and parses JSON
+
+    // --- Normalize inspectData into a flat list of containers ---
+    let allContainers: ClabJSON[] = [];
+    if (inspectData && Array.isArray(inspectData.containers)) {
+      // Old format: Top-level "containers" array
+      console.log("[discovery]:\tDetected old inspect format (flat container list).");
+      allContainers = inspectData.containers;
+    } else if (inspectData && typeof inspectData === 'object' && !Array.isArray(inspectData) && Object.keys(inspectData).length > 0) {
+      // New format: Object with lab names as keys
+      console.log("[discovery]:\tDetected new inspect format (grouped by lab).");
+      for (const labName in inspectData) {
+        if (Array.isArray(inspectData[labName])) {
+          // Add containers from this lab to the flat list
+          // Ensure each container object has the necessary fields (like labPath, absLabPath if needed)
+          // The sample output shows labPath and absLabPath are present in the new format too.
+          allContainers.push(...inspectData[labName]);
+        }
+      }
+    } else {
+      // Handle cases where inspectData is invalid, empty, or not the expected object/array
+      console.log("[discovery]:\tInspect data is empty or in an unexpected format.");
       this.updateBadge(0);
+      this.labsCache.inspect = { data: undefined, timestamp: Date.now() }; // Cache empty result
       return undefined;
     }
 
+    // If after normalization, we have no containers, return undefined
+    if (allContainers.length === 0) {
+      this.updateBadge(0);
+      this.labsCache.inspect = { data: undefined, timestamp: Date.now() }; // Cache empty result
+      return undefined;
+    }
+
+    // --- Process the flat allContainers list ---
     const labs: Record<string, ClabLabTreeNode> = {};
 
-    // The 'containers' array in the JSON contains data for each deployed container
-    inspectData.containers.forEach((container: ClabJSON) => {
-      const normPath = utils.normalizeLabPath(container.labPath);
+    allContainers.forEach((container: ClabJSON) => {
+      // Use absLabPath if available, otherwise normalize labPath as fallback
+      const normPath = container.absLabPath || utils.normalizeLabPath(container.labPath);
+
       if (!labs[normPath]) {
+        // This is the first container we see for this lab path
         const label = `${container.lab_name} (${container.owner})`;
 
         const labPathObj: LabPath = {
           absolute: normPath,
-          relative: utils.getRelLabFolderPath(container.labPath)
+          // Use relative path from the container data if possible, else calculate
+          relative: utils.getRelativeFolderPath(normPath) // Or use a calculated relative path
         };
 
-        // Discover the containers for this lab
-        const discoveredContainers: ClabContainerTreeNode[] =
-          this.discoverContainers(inspectData, container.labPath, labPathObj.absolute);
+        // Filter the flat list to get all containers for *this specific lab path*
+        const containersForThisLab = allContainers.filter(
+          (c: ClabJSON) => (c.absLabPath || utils.normalizeLabPath(c.labPath)) === normPath
+        );
 
-        // Count how many are running
+        // Discover the container nodes for this lab using the filtered list
+        const discoveredContainers: ClabContainerTreeNode[] =
+          this.discoverContainers(containersForThisLab, labPathObj.absolute); // Pass filtered list
+
+        // Determine lab icon based on container states
         let runningCount = 0;
         for (const c of discoveredContainers) {
           if (c.state === "running") {
             runningCount++;
           }
         }
-
-        // Pick icon
         let icon: string;
-        if (runningCount === 0) {
+        if (runningCount === 0 && discoveredContainers.length > 0) { // Check length > 0
           icon = CtrStateIcons.STOPPED;
         } else if (runningCount === discoveredContainers.length) {
           icon = CtrStateIcons.RUNNING;
-        } else {
+        } else if (discoveredContainers.length > 0) { // Only show partial if there are containers
           icon = CtrStateIcons.PARTIAL;
+        } else {
+           icon = CtrStateIcons.STOPPED; // Default if no containers somehow (shouldn't happen here)
         }
+
 
         const labNode = new ClabLabTreeNode(
           label,
-          vscode.TreeItemCollapsibleState.Collapsed,
+          vscode.TreeItemCollapsibleState.Collapsed, // Always collapsed initially for deployed labs
           labPathObj,
           container.lab_name,
           container.owner,
           discoveredContainers,
-          "containerlabLabDeployed"
+          "containerlabLabDeployed" // Context value for deployed labs
         );
-        labNode.description = labPathObj.relative;
+        labNode.description = labPathObj.relative; // Show relative path
 
         const iconUri = this.getResourceUri(icon);
         labNode.iconPath = { light: iconUri, dark: iconUri };
@@ -392,7 +437,7 @@ export class ClabTreeDataProvider implements vscode.TreeDataProvider<ClabLabTree
 
     this.updateBadge(Object.keys(labs).length);
 
-    this.labsCache.inspect = { data: labs, timestamp: Date.now() };
+    this.labsCache.inspect = { data: labs, timestamp: Date.now() }; // Cache the result
     return labs;
   }
 
@@ -421,15 +466,13 @@ export class ClabTreeDataProvider implements vscode.TreeDataProvider<ClabLabTree
   /**
    * Discover containers that belong to a specific lab path.
    */
-  private discoverContainers(inspectData: any, labPath: string, absLabPath: string): ClabContainerTreeNode[] {
-    console.log(`[discovery]:\tDiscovering containers for ${labPath}...`);
+  private discoverContainers(containersForThisLab: ClabJSON[], absLabPath: string): ClabContainerTreeNode[] {
+    console.log(`[discovery]:\tProcessing ${containersForThisLab.length} containers for ${absLabPath}...`);
 
-    // filter the data to only relevant containers
-    const filtered = inspectData.containers.filter((container: ClabJSON) => container.labPath === labPath);
-    let containers: ClabContainerTreeNode[] = [];
+    let containerNodes: ClabContainerTreeNode[] = [];
 
-    filtered.forEach((container: ClabJSON) => {
-      let tooltip = [
+    containersForThisLab.forEach((container: ClabJSON) => {
+      let tooltipParts = [
         `Container: ${container.name}`,
         `ID: ${container.container_id}`,
         `State: ${container.state}`,
@@ -437,213 +480,254 @@ export class ClabTreeDataProvider implements vscode.TreeDataProvider<ClabLabTree
         `Image: ${container.image}`
       ];
 
-      if (!(container.ipv4_address === "N/A")) {
-        const v4Addr = container.ipv4_address.split('/')[0];
-        tooltip.push(`IPv4: ${v4Addr}`);
+      // Add IPs to tooltip if valid
+      const v4Addr = container.ipv4_address?.split('/')[0];
+      if (v4Addr && v4Addr !== "N/A") {
+        tooltipParts.push(`IPv4: ${v4Addr}`);
+      }
+      const v6Addr = container.ipv6_address?.split('/')[0];
+      if (v6Addr && v6Addr !== "N/A") {
+        tooltipParts.push(`IPv6: ${v6Addr}`);
       }
 
-      if (!(container.ipv6_address === "N/A")) {
-        const v6Addr = container.ipv6_address.split('/')[0];
-        tooltip.push(`IPv6: ${v6Addr}`);
-      }
+      // Determine icon based on state
+      const icon = container.state === "running" ? CtrStateIcons.RUNNING : CtrStateIcons.STOPPED;
 
-      let icon: string;
-      if (container.state === "running") { icon = CtrStateIcons.RUNNING; }
-      else { icon = CtrStateIcons.STOPPED; }
-
+      // Discover interfaces for this specific container
+      // The interface discovery logic already uses caching based on container ID and state
       const interfaces = this.discoverContainerInterfaces(
-        absLabPath,
+        absLabPath, // Pass the absolute path of the lab file
         container.name,
         container.container_id,
-        container.state // Pass container state to discovery
-      ).sort((a, b) => a.name.localeCompare(b.name));
+        container.state // Pass container state for cache validation
+      ).sort((a, b) => a.name.localeCompare(b.name)); // Sort interfaces alphabetically
 
+      // Determine collapsible state based on interfaces
       const collapsible = interfaces.length > 0
         ? vscode.TreeItemCollapsibleState.Collapsed
         : vscode.TreeItemCollapsibleState.None;
 
+      // Create the container node
       const node = new ClabContainerTreeNode(
-        container.name,
+        container.name, // Use container name as label
         collapsible,
         container.name,
         container.container_id,
         container.state,
         container.kind,
         container.image,
-        interfaces,
-        { absolute: absLabPath, relative: utils.getRelLabFolderPath(labPath) },
-        container.ipv4_address,
-        container.ipv6_address,
-        "containerlabContainer"
+        interfaces, // Assign discovered interfaces
+        { absolute: absLabPath, relative: utils.getRelLabFolderPath(container.labPath) }, // Lab path info
+        container.ipv4_address, // Full address with mask
+        container.ipv6_address, // Full address with mask
+        "containerlabContainer" // Context value
       );
 
+      // Set description (e.g., "Running", "Stopped") and tooltip
       node.description = utils.titleCase(container.state);
-      node.tooltip = tooltip.join("\n");
+      node.tooltip = tooltipParts.join("\n");
 
+      // Set icon path
       const iconPath = this.getResourceUri(icon);
       node.iconPath = { light: iconPath, dark: iconPath };
 
-      containers.push(node);
+      containerNodes.push(node);
     });
 
-    return containers;
+    // Sort container nodes alphabetically by name
+    return containerNodes.sort((a, b) => a.name.localeCompare(b.name));
   }
 
   private discoverContainerInterfaces(
-    labPath: string,
+    absLabPath: string, // Use absolute lab path
     cName: string,
     cID: string,
     containerState: string
   ): ClabInterfaceTreeNode[] {
     const CACHE_TTL = 30000; // 30 seconds
-    const normalizedLabPath = utils.normalizeLabPath(labPath);
-    const cacheKey = `${normalizedLabPath}::${cName}::${cID}`;
+    // Use a consistent cache key including the absolute path
+    const cacheKey = `${absLabPath}::${cName}::${cID}`;
 
     // Cache validation check
     if (this.containerInterfacesCache.has(cacheKey)) {
       const cached = this.containerInterfacesCache.get(cacheKey)!;
-      const valid = cached.state === containerState &&
-                   Date.now() - cached.timestamp < CACHE_TTL;
+      // Check if container state matches and cache is not expired
+      const isValid = cached.state === containerState &&
+                     (Date.now() - cached.timestamp < CACHE_TTL);
 
-      if (valid) return cached.interfaces;
+      if (isValid) {
+         // console.log(`[cache] HIT interfaces for ${cName} (${containerState})`);
+         return cached.interfaces;
+      } else {
+         // console.log(`[cache] STALE interfaces for ${cName} (Cached: ${cached.state}, Current: ${containerState}, Age: ${Date.now() - cached.timestamp}ms)`);
+      }
+    } else {
+       // console.log(`[cache] MISS interfaces for ${cName} (${containerState})`);
     }
+
 
     let interfaces: ClabInterfaceTreeNode[] = [];
 
     try {
+      // IMPORTANT: Use the absolute lab path in the command
+      const cmd = `${utils.getSudo()}containerlab inspect interfaces -t "${absLabPath}" -f json -n ${cName}`;
+      // Use execSync for simplicity here, assuming it's fast enough. Add timeout if needed.
       const clabStdout = execSync(
-        `${utils.getSudo()}containerlab inspect interfaces -t ${labPath} -f json -n ${cName}`,
-        { stdio: ['pipe', 'pipe', 'ignore'] }
+        cmd,
+        { stdio: ['pipe', 'pipe', 'ignore'], timeout: 10000 } // 10s timeout
       ).toString();
 
       const clabInsJSON: ClabInsIntfJSON[] = JSON.parse(clabStdout);
 
-      clabInsJSON[0].interfaces.forEach(intf => {
-        if (intf.state === "unknown") return;
+      // Check if the expected structure is present
+      if (clabInsJSON && clabInsJSON.length > 0 && Array.isArray(clabInsJSON[0].interfaces)) {
+          clabInsJSON[0].interfaces.forEach(intf => {
+            // Skip interfaces in 'unknown' state or loopback 'lo'
+            if (intf.state === "unknown" || intf.name === "lo") return;
 
-        let tooltip: string[] = [
-          `Name: ${intf.name}`,
-          `State: ${intf.state}`,
-          `Type: ${intf.type}`,
-          `MAC: ${intf.mac}`,
-          `MTU: ${intf.mtu}`
-        ];
+            let tooltipParts: string[] = [
+              `Name: ${intf.name}`,
+              `State: ${intf.state}`,
+              `Type: ${intf.type}`,
+              `MAC: ${intf.mac}`,
+              `MTU: ${intf.mtu}`
+            ];
 
-        let label: string = intf.name;
-        let description: string = intf.state.toUpperCase();
+            let label: string = intf.name;
+            let description: string = intf.state.toUpperCase();
 
-        if (intf.alias) {
-          label = intf.alias;
-          tooltip[1] = `Alias: ${intf.alias}`;
-          description = `${intf.state.toUpperCase()} - ${intf.name}`;
-        }
+            // Use alias if available
+            if (intf.alias) {
+              label = intf.alias;
+              tooltipParts.splice(1, 0, `Alias: ${intf.alias}`); // Insert alias after name
+              description = `${intf.state.toUpperCase()} (${intf.name})`; // Show state and real name
+            }
 
-        // Determine icons based on interface state
-        let iconLight: vscode.Uri;
-        let iconDark: vscode.Uri;
-        const contextValue = this.getInterfaceContextValue(intf.state);
+            // Determine icons and context value based on interface state
+            let iconLight: vscode.Uri;
+            let iconDark: vscode.Uri;
+            const contextValue = this.getInterfaceContextValue(intf.state);
 
-        if (intf.state === "up") {
-          iconLight = this.getResourceUri(IntfStateIcons.UP);
-          iconDark = this.getResourceUri(IntfStateIcons.UP);
-        } else if (intf.state === "down") {
-          iconLight = this.getResourceUri(IntfStateIcons.DOWN);
-          iconDark = this.getResourceUri(IntfStateIcons.DOWN);
-        } else {
-          iconLight = this.getResourceUri(IntfStateIcons.LIGHT);
-          iconDark = this.getResourceUri(IntfStateIcons.DARK);
-        }
+            switch (intf.state) {
+              case "up":
+                iconLight = this.getResourceUri(IntfStateIcons.UP);
+                iconDark = this.getResourceUri(IntfStateIcons.UP);
+                break;
+              case "down":
+                iconLight = this.getResourceUri(IntfStateIcons.DOWN);
+                iconDark = this.getResourceUri(IntfStateIcons.DOWN);
+                break;
+              default: // Should not happen if we skip 'unknown'
+                iconLight = this.getResourceUri(IntfStateIcons.LIGHT);
+                iconDark = this.getResourceUri(IntfStateIcons.DARK);
+                break;
+            }
 
-        const node = new ClabInterfaceTreeNode(
-          label,
-          vscode.TreeItemCollapsibleState.None,
-          cName,
-          cID,
-          intf.name,
-          intf.type,
-          intf.alias,
-          intf.mac,
-          intf.mtu,
-          intf.ifindex,
-          intf.state,  // Store raw state value
-          contextValue
-        );
+            const node = new ClabInterfaceTreeNode(
+              label,
+              vscode.TreeItemCollapsibleState.None,
+              cName, // parent container name
+              cID,   // parent container ID
+              intf.name, // interface name
+              intf.type,
+              intf.alias,
+              intf.mac,
+              intf.mtu,
+              intf.ifindex,
+              intf.state, // Store raw state value
+              contextValue
+            );
 
-        node.tooltip = tooltip.join("\n");
-        node.description = description;
-        node.iconPath = { light: iconLight, dark: iconDark };
+            node.tooltip = tooltipParts.join("\n");
+            node.description = description;
+            node.iconPath = { light: iconLight, dark: iconDark };
 
-        interfaces.push(node);
-      });
+            interfaces.push(node);
+          });
+      } else {
+          console.warn(`[discovery]: Unexpected JSON structure from inspect interfaces for ${cName}`);
+      }
 
-      // Update cache with state and timestamp
+
+      // Update cache with current state and timestamp
       this.containerInterfacesCache.set(cacheKey, {
         state: containerState,
         timestamp: Date.now(),
         interfaces
       });
 
-      console.log(`[cache] Stored interfaces for ${cName} (${containerState})`);
+      // console.log(`[cache] STORED interfaces for ${cName} (${containerState})`);
 
-    } catch (err) {
-      console.error(`Interface detection failed for ${cName}. ${err instanceof Error ? err.message : String(err)}`);
+    } catch (err: any) {
+      // Log specific errors
+      if (err.killed || err.signal === 'SIGTERM') {
+         console.error(`[discovery]: Interface detection timed out for ${cName}. Cmd: ${err.cmd}`);
+      } else {
+         console.error(`[discovery]: Interface detection failed for ${cName}. ${err.message || String(err)}`);
+      }
+      // Clear cache entry on error to force refetch next time
+      this.containerInterfacesCache.delete(cacheKey);
     }
 
-    return interfaces;
+    return interfaces; // Return potentially empty array on error
   }
 
+
+  // getInterfaceContextValue remains unchanged
   private getInterfaceContextValue(state: string): string {
     return state === 'up' ? 'containerlabInterfaceUp' : 'containerlabInterfaceDown';
   }
 
+  // startCacheJanitor remains unchanged
   private startCacheJanitor() {
     setInterval(() => {
       const now = Date.now();
       let hasExpired = false;
+      const cacheTTL = 30000; // Use consistent TTL
 
       // Check for expired container interfaces
       this.containerInterfacesCache.forEach((value, key) => {
-        if (now - value.timestamp > 30000) { // 30s TTL
+        if (now - value.timestamp > cacheTTL) {
           this.containerInterfacesCache.delete(key);
           hasExpired = true;
         }
       });
 
       // Check for expired labs caches
-      if (this.labsCache.local && now - this.labsCache.local.timestamp > 30000) {
+      if (this.labsCache.local && now - this.labsCache.local.timestamp > cacheTTL) {
         this.labsCache.local = null;
         hasExpired = true;
       }
 
-      if (this.labsCache.inspect && now - this.labsCache.inspect.timestamp > 30000) {
+      if (this.labsCache.inspect && now - this.labsCache.inspect.timestamp > cacheTTL) {
         this.labsCache.inspect = null;
         hasExpired = true;
       }
 
       // Only fire the event if something actually expired
       if (hasExpired) {
+        // console.log("[cache]: Janitor expired some cache entries, refreshing tree.");
         this._onDidChangeTreeData.fire();
       }
     }, 10000); // Check every 10 seconds
   }
 
-  /**
-  * Convert the filepath of something in the ./resources dir
-  * to an extension context Uri.
-  */
+  // getResourceUri remains unchanged
   private getResourceUri(resource: string) {
     return vscode.Uri.file(this.context.asAbsolutePath(path.join("resources", resource)));
   }
 
+  // updateBadge remains unchanged
   private updateBadge(runningLabs: number) {
+    if (!treeView) return; // Guard against treeView not being initialized yet
+
     if (runningLabs < 1) {
       treeView.badge = undefined;
     } else {
       treeView.badge = {
         value: runningLabs,
         tooltip: `${runningLabs} running lab(s)`
-      }
+      };
     }
-
   }
 }


### PR DESCRIPTION
With the upcoming release ( 0.68.0, currently we are in 0.67.0) of containerlab the inspect --format json format will change
https://github.com/srl-labs/containerlab/pull/2552

This patch, will convert to new to the old format. This is just a intermediate patch, a few weeks after the release of 0.68.0, we will drop the suport of 0.67.0 and lower. 