### PR TITLE
update environment.json to get the data from live cy instance

### DIFF
--- a/src/topoViewer/backend/topoViewerAdaptorClab.ts
+++ b/src/topoViewer/backend/topoViewerAdaptorClab.ts
@@ -112,8 +112,7 @@ export class TopoViewerAdaptorClab {
         deploymentType: "vs-code",
         topoviewerVersion: `${topoViewerVersion}`,
         topviewerPresetLayout: `${this.currentIsPresetLayout.toString()}`,
-        envCyTopoJsonBytes: cytoTopology,
-        envCyTopoJsonBytesAddon: cytoTopology
+        envCyTopoJsonBytes: cytoTopology
       };
 
       // Serialize EnvironmentJson with hyphenated keys
@@ -256,8 +255,7 @@ export class TopoViewerAdaptorClab {
       "deployment-type": envJson.deploymentType,
       "topoviewer-version": envJson.topoviewerVersion,
       "topoviewer-layout-preset": envJson.topviewerPresetLayout,
-      "EnvCyTopoJsonBytes": envJson.envCyTopoJsonBytes,
-      "EnvCyTopoJsonBytesAddon": envJson.envCyTopoJsonBytesAddon
+      "EnvCyTopoJsonBytes": envJson.envCyTopoJsonBytes
     };
 
     return JSON.stringify(hyphenatedJson, null, 2);

--- a/src/topoViewer/backend/topoViewerAdaptorClab.ts
+++ b/src/topoViewer/backend/topoViewerAdaptorClab.ts
@@ -94,7 +94,10 @@ export class TopoViewerAdaptorClab {
 
 
       var clabName = parsed.name
-
+      var clabPrefix = parsed.prefix;
+      // if (clabPrefix == "") {
+      //   clabPrefix = ""
+      // }
 
 
       // Define the EnvironmentJson object
@@ -104,6 +107,7 @@ export class TopoViewerAdaptorClab {
 
       const environmentJson: EnvironmentJson = {
         workingDirectory: ".",
+        clabPrefix: `${clabPrefix}`,
         clabName: `${clabName}`,
         clabServerAddress: "",
         clabAllowedHostname: hostname,
@@ -174,9 +178,9 @@ export class TopoViewerAdaptorClab {
    * @returns An array of Cytoscape elements (`CyElement[]`) representing nodes and edges.
    */
   public clabYamlToCytoscapeElements(yamlContent: string, clabTreeDataToTopoviewer: Record<string, ClabLabTreeNode> | undefined): CyElement[] {
-        const parsed = yaml.load(yamlContent) as ClabTopology;
-      return this.buildCytoscapeElements(parsed, { includeContainerData: true, clabTreeData: clabTreeDataToTopoviewer });
-    }
+    const parsed = yaml.load(yamlContent) as ClabTopology;
+    return this.buildCytoscapeElements(parsed, { includeContainerData: true, clabTreeData: clabTreeDataToTopoviewer });
+  }
 
 
   /**
@@ -192,9 +196,9 @@ export class TopoViewerAdaptorClab {
    * @returns An array of Cytoscape elements (`CyElement[]`) representing nodes and edges.
    */
   public clabYamlToCytoscapeElementsEditor(yamlContent: string): CyElement[] {
-      const parsed = yaml.load(yamlContent) as ClabTopology;
-      return this.buildCytoscapeElements(parsed, { includeContainerData: false });
-    }
+    const parsed = yaml.load(yamlContent) as ClabTopology;
+    return this.buildCytoscapeElements(parsed, { includeContainerData: false });
+  }
 
 
   /**
@@ -247,6 +251,7 @@ export class TopoViewerAdaptorClab {
   private mapEnvironmentJsonToHyphenated(envJson: EnvironmentJson): string {
     const hyphenatedJson = {
       "working-directory": envJson.workingDirectory,
+      "clab-prefix": envJson.clabPrefix,
       "clab-name": envJson.clabName,
       "clab-server-address": envJson.clabServerAddress,
       "clab-allowed-hostname": envJson.clabAllowedHostname,
@@ -282,6 +287,8 @@ export class TopoViewerAdaptorClab {
     log.info(`######### status preset layout: ${this.currentIsPresetLayout}`);
 
     const clabName = parsed.name;
+
+
     const parentMap = new Map<string, string | undefined>();
     let nodeIndex = 0;
 

--- a/src/topoViewer/backend/topoViewerWebUiFacade.ts
+++ b/src/topoViewer/backend/topoViewerWebUiFacade.ts
@@ -642,6 +642,36 @@ export class TopoViewer {
             }
             break;
           }
+
+          case 'save-environment-json-to-disk': {
+            try {
+              const environmentData = JSON.parse(payload as string);
+
+              if (!this.lastFolderName) {
+                throw new Error('No folderName available (this.lastFolderName is undefined).');
+              }
+
+              // Construct full path under `topoViewerData/<folder>/environment.json`
+              const environmentJsonPath = vscode.Uri.joinPath(
+                this.context.extensionUri,
+                'topoViewerData',
+                this.lastFolderName,
+                'environment.json'
+              );
+
+              // Write to disk
+              await fs.promises.writeFile(environmentJsonPath.fsPath, JSON.stringify(environmentData, null, 2), 'utf8');
+
+              result = `Environment JSON successfully saved to disk at ${environmentJsonPath.fsPath}`;
+              log.info(result);
+              vscode.window.showInformationMessage("Environment saved to disk.");
+            } catch (innerError) {
+              result = `Error saving environment JSON to disk.`;
+              log.error(`Error in 'save-environment-json-to-disk': ${JSON.stringify(innerError, null, 2)}`);
+            }
+            break;
+          }
+
           default: {
             error = `Unknown endpoint "${endpointName}".`;
             log.error(error);

--- a/src/topoViewer/backend/topoViewerWebUiFacade.ts
+++ b/src/topoViewer/backend/topoViewerWebUiFacade.ts
@@ -664,7 +664,6 @@ export class TopoViewer {
 
               result = `Environment JSON successfully saved to disk at ${environmentJsonPath.fsPath}`;
               log.info(result);
-              vscode.window.showInformationMessage("Environment saved to disk.");
             } catch (innerError) {
               result = `Error saving environment JSON to disk.`;
               log.error(`Error in 'save-environment-json-to-disk': ${JSON.stringify(innerError, null, 2)}`);

--- a/src/topoViewer/backend/types/topoViewerType.ts
+++ b/src/topoViewer/backend/types/topoViewerType.ts
@@ -56,6 +56,7 @@ export type CytoTopology = CyElement[];
  */
 export interface EnvironmentJson {
     workingDirectory: string;
+    clabPrefix: string;
     clabName: string;
     clabServerAddress: string;
     clabAllowedHostname: string;

--- a/src/topoViewer/backend/types/topoViewerType.ts
+++ b/src/topoViewer/backend/types/topoViewerType.ts
@@ -65,7 +65,6 @@ export interface EnvironmentJson {
     topoviewerVersion: string;
     topviewerPresetLayout: string
     envCyTopoJsonBytes: CytoTopology | '';
-    envCyTopoJsonBytesAddon: CytoTopology | '';
 }
 
 

--- a/src/topoViewer/webview-ui/html-static/js/common.js
+++ b/src/topoViewer/webview-ui/html-static/js/common.js
@@ -13,6 +13,7 @@ var globalNodeContainerStatusVisibility = false;
 var globalShellUrl = "/js/cloudshell";
 let deploymentType;
 var globalLabName;
+var globalPrefixName
 var multiLayerViewPortState = false;
 
 // Cytoscape-Leaflet variables
@@ -69,6 +70,7 @@ async function initEnv() {
 
     // Assign to global variables
     globalLabName = environments["clab-name"];
+    globalPrefixName = environments["clab-prefix"];
     deploymentType = environments["deployment-type"];
     globalIsPresetLayout = environments["topoviewer-layout-preset"] === "true";
     globalAllowedhostname = environments["clab-allowed-hostname"];

--- a/src/topoViewer/webview-ui/html-static/js/dev.js
+++ b/src/topoViewer/webview-ui/html-static/js/dev.js
@@ -2374,8 +2374,9 @@ async function linkWireshark(event, option, endpoint, referenceElementAfterId) {
             netNsResponse = await sendRequestToEndpointGetV3("/clab-node-network-namespace", [clabSourceLongName]);
             netNsId = extractNamespaceId(netNsResponse.namespace_id);
             console.info("linkWireshark - netNsSource: ", netNsId);
-
             urlParams = `container={"netns":${netNsId},"network-interfaces":["${clabSourcePort}"],"name":"${clabSourceLongName.toLowerCase()}","type":"docker","prefix":""}&nif=${clabSourcePort}`;
+            const edgeSharkHref = baseUrl + urlParams;
+            console.info("linkWireshark - edgeSharkHref: ", edgeSharkHref);
           }
         } else if (endpoint === "target") {
           if (isVscodeDeployment) {
@@ -2393,10 +2394,11 @@ async function linkWireshark(event, option, endpoint, referenceElementAfterId) {
             netNsId = extractNamespaceId(netNsResponse.namespace_id);
             console.info("linkWireshark - netNsTarget: ", netNsId);
             urlParams = `container={"netns":${netNsId},"network-interfaces":["${clabTargetPort}"],"name":"${clabTargetLongName.toLowerCase()}","type":"docker","prefix":""}&nif=${clabTargetPort}`;
+            const edgeSharkHref = baseUrl + urlParams;
+            console.info("linkWireshark - edgeSharkHref: ", edgeSharkHref);
           }
         }
-        const edgeSharkHref = baseUrl + urlParams;
-        console.info("linkWireshark - edgeSharkHref: ", edgeSharkHref);
+
 
         // window.open(edgeSharkHref);
 

--- a/src/topoViewer/webview-ui/html-static/js/managerSocketDataEnrichment.js
+++ b/src/topoViewer/webview-ui/html-static/js/managerSocketDataEnrichment.js
@@ -48,45 +48,76 @@
 function socketDataEncrichmentLink(labData) {
   const linkMap = new Map();
 
-  // Iterate through all lab entries and gather interface data from matching lab
+  console.log(`debug labData:`, labData);
+  console.log(`debug labData.name`, labData.name);
+  console.log(`debug globalLabName`, globalLabName);
+
+  // Build interface key mapping for the current lab
   Object.values(labData).forEach(lab => {
     if (lab.name !== globalLabName || !Array.isArray(lab.containers)) return;
 
     lab.containers.forEach(container => {
       if (typeof container.label !== 'string' || !Array.isArray(container.interfaces)) return;
 
-      // Derive short node name by stripping lab prefix from the container label
       const nodeName = container.label.split(lab.name)[1]?.replace(/^-/, '') || container.label;
 
-      // Build key per interface and store MAC/MTU/type
       container.interfaces.forEach(iface => {
         const key = `${lab.name}::${nodeName}::${iface.label}`;
         linkMap.set(key, { mac: iface.mac, mtu: iface.mtu, type: iface.type });
       });
+
       console.log(`Enriched link data for node: ${nodeName} with interfaces:`, container.interfaces);
+      console.log(`Enriched link map data:`, linkMap);
     });
   });
 
-  // Match the key parts with Cytoscape edge's source/target endpoint data
+  // Compute prefix safely
+  let assignedPrefixLabName;
+
+  switch (true) {
+    case typeof globalPrefixName === "string" && globalPrefixName.trim() === "undefined":
+      assignedPrefixLabName = `clab-${globalLabName}-`;
+      break;
+
+    case typeof globalPrefixName === "string" && globalPrefixName.trim() !== "":
+      assignedPrefixLabName = `${globalPrefixName.trim()}-${globalLabName}-`;
+      break;
+
+    default:
+      assignedPrefixLabName = null;
+      break;
+  }
+
+  // Enrich edges
   linkMap.forEach((iface, key) => {
     const [, nodeName, endpoint] = key.split('::');
     cy.edges().forEach(edge => {
       const data = edge.data();
 
-      console.log(`Enriching edge: ${data.source} -> ${data.target} with endpoint: ${endpoint}`);
+      // Safely build clabSourceLongName and clabTargetLongName
+      const clabSourceLongName = assignedPrefixLabName
+        ? `${assignedPrefixLabName}${data.source}`
+        : data.source;
+
+      const clabTargetLongName = assignedPrefixLabName
+        ? `${assignedPrefixLabName}${data.target}`
+        : data.target;
+
       const updatedExtraData = {
         ...edge.data('extraData'),
-        clabSourceLongName: data.source,
-        clabTargetLongName: data.target,
+        clabSourceLongName,
+        clabTargetLongName
       };
       edge.data('extraData', updatedExtraData);
 
+      // Enrich with interface details if matched
       if (data.source === nodeName && data.sourceEndpoint === endpoint) {
         edge.data({ sourceMac: iface.mac, sourceMtu: iface.mtu, sourceType: iface.type });
       }
       if (data.target === nodeName && data.targetEndpoint === endpoint) {
         edge.data({ targetMac: iface.mac, targetMtu: iface.mtu, targetType: iface.type });
       }
+
       console.log(`Edge data after enrichment:`, edge.data());
     });
   });


### PR DESCRIPTION

**Issue:**
The topology `prefix` handling was previously inconsistent. And this impacting the `edgeShark` handling from TopoViewer.


**Fix Strategy:**
Update the `environment.json` file by enriching its `EnvCyTopoJsonBytes` field using live topology data from the active Cytoscape (`cy`) instance. This enrichment process correctly computes the prefix using production-grade logic and ensures that each edge contains accurate `clabSourceLongName` and `clabTargetLongName` values. The prefix logic now safely handles invalid or missing values, avoiding unintended `"null"` strings.

---

**ausfügrung-01:**

* **Prefix handling in topology:** The `edgeShark` handler reads link data from the updated `environment.json`. Since this file is refreshed using `cy.elements().jsons()` enriched by the prefix-aware logic, it reflects the correct topology state. This ensures that all node and edge names — including those with optional prefixes — are consistent and valid for downstream processing.


https://github.com/user-attachments/assets/2492da3f-b398-421c-ab45-be3bf8ed836e

