### PR TITLE
Use current extension version for welcome page badge

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,6 +33,8 @@ export let runningLabsProvider: RunningLabTreeDataProvider;
 export let helpFeedbackProvider: HelpFeedbackProvider;
 export let sshxSessions: Map<string, string> = new Map();
 
+export const extensionVersion = vscode.extensions.getExtension('srl-labs.vscode-containerlab')?.packageJSON.version;
+
 export async function refreshSshxSessions() {
   try {
     const out = await runWithSudo(

--- a/src/welcomePage.ts
+++ b/src/welcomePage.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as https from 'https';
+import { extensionVersion } from './extension';
 
 /**
  * Manages the welcome page webview for the Containerlab extension.
@@ -258,7 +259,7 @@ topology:
                 <h1 class="text-3xl">Welcome to Containerlab</h1>
                 <div class="inline-flex gap-x-2 mt-2">
                   <a href="https://github.com/srl-labs/vscode-containerlab/releases/">
-                      <img src="https://img.shields.io/github/v/release/srl-labs/vscode-containerlab.svg?style=flat-square&color=00c9ff&labelColor=bec8d2" alt="Latest extension version" />
+                      <img src="https://img.shields.io/badge/version-${extensionVersion}-blue?style=flat-square&color=00c9ff&labelColor=bec8d2" alt="Installed Extension Version" />
                   </a>
                   <a href="https://github.com/srl-labs/containerlab/releases/latest">
                       <img src="https://img.shields.io/github/release/srl-labs/containerlab.svg?style=flat-square&color=00c9ff&labelColor=bec8d2" alt="Latest containerlab version" />


### PR DESCRIPTION
Showing the latest release on the welcome page is not as useful as showing the currently installed version of the extension.