### PR TITLE
Enhance topoeditor for new YAML specs

### DIFF
--- a/src/topoViewer/backend/types/topoViewerType.ts
+++ b/src/topoViewer/backend/types/topoViewerType.ts
@@ -26,6 +26,9 @@ export interface ClabTopology {
     name?: string
     prefix?: string;
     topology?: {
+        defaults?: ClabNode;
+        kinds?: Record<string, ClabNode>;
+        groups?: Record<string, ClabNode>;
         nodes?: Record<string, ClabNode>;
         links?: ClabLink[];
     };

--- a/src/topoViewerEditor/backend/topoViewerEditorWebUiFacade.ts
+++ b/src/topoViewerEditor/backend/topoViewerEditorWebUiFacade.ts
@@ -658,7 +658,9 @@ topology:
                   const existingImage = (nodeMap.get('image', true) as any)?.value;
                   const existingType = (nodeMap.get('type', true) as any)?.value;
 
-                  const groupName = extraData.group || (element.parent ? element.parent.split(':')[0] : undefined) || (nodeMap.get('group', true) as any)?.value;
+                  // const groupName = extraData.group || (element.parent ? element.parent.split(':')[0] : undefined) || (nodeMap.get('group', true) as any)?.value;
+                  const groupName = extraData.group ?? (nodeMap.get('group', true) as any)?.value;
+
                   const desiredKind = extraData.kind ?? existingKind ?? element.data.topoViewerRole;
                   const desiredImage = extraData.image ?? existingImage;
                   const desiredType = extraData.type ?? existingType;
@@ -937,7 +939,8 @@ topology:
                   const existingImage = (nodeMap.get('image', true) as any)?.value;
                   const existingType = (nodeMap.get('type', true) as any)?.value;
 
-                  const groupName = extraData.group || (element.parent ? element.parent.split(':')[0] : undefined) || (nodeMap.get('group', true) as any)?.value;
+                  // const groupName = extraData.group || (element.parent ? element.parent.split(':')[0] : undefined) || (nodeMap.get('group', true) as any)?.value;
+                  const groupName = extraData.group ?? (nodeMap.get('group', true) as any)?.value;
                   const desiredKind = extraData.kind ?? existingKind ?? element.data.topoViewerRole;
                   const desiredImage = extraData.image ?? existingImage;
                   const desiredType = extraData.type ?? existingType;

--- a/src/topoViewerEditor/backend/topoViewerEditorWebUiFacade.ts
+++ b/src/topoViewerEditor/backend/topoViewerEditorWebUiFacade.ts
@@ -11,6 +11,7 @@ import { log } from '../../topoViewer/backend/logger';
 import { getHTMLTemplate } from '../webview-ui/template/vscodeHtmlTemplate';
 import { TopoViewerAdaptorClab } from '../../topoViewer/backend/topoViewerAdaptorClab';
 import { ClabLabTreeNode } from "../../treeView/common";
+import { ClabTopology, ClabNode } from '../../topoViewer/backend/types/topoViewerType';
 
 /**
  * Class representing the TopoViewer Editor Webview Panel.
@@ -43,6 +44,36 @@ export class TopoViewerEditor {
 
   private sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  /**
+   * Applies Containerlab inheritance rules to compute the effective
+   * configuration for a node. The precedence order is:
+   * node -> group -> kind -> defaults.
+   */
+  private resolveNodeConfig(parsed: ClabTopology, node: ClabNode): ClabNode {
+    const defaults = parsed.topology?.defaults ?? {};
+    const groups = parsed.topology?.groups ?? {};
+    const kinds = parsed.topology?.kinds ?? {};
+
+    const groupCfg = node.group && groups[node.group] ? groups[node.group] : {};
+    const kindName = node.kind ?? groupCfg.kind ?? defaults.kind;
+    const kindCfg = kindName && kinds[kindName] ? kinds[kindName] : {};
+
+    const merged: ClabNode = {
+      ...defaults,
+      ...kindCfg,
+      ...groupCfg,
+      ...node,
+    };
+    merged.kind = kindName;
+    merged.labels = {
+      ...(defaults.labels ?? {}),
+      ...(kindCfg.labels ?? {}),
+      ...(groupCfg.labels ?? {}),
+      ...(node.labels ?? {}),
+    };
+    return merged;
   }
 
   private async validateYaml(yamlContent: string): Promise<boolean> {
@@ -602,6 +633,9 @@ topology:
               }
               const yamlNodes: YAML.YAMLMap = nodesMaybe;
 
+              // Parse topology for inheritance calculations
+              const topoObj = doc.toJS() as ClabTopology;
+
               // Iterate through payload nodes to add/update nodes in YAML.
               payloadParsed
                 .filter(el => el.group === 'nodes' && el.data.topoViewerRole !== 'group')
@@ -621,23 +655,38 @@ topology:
 
                   // Update the node's core properties while preserving existing values.
                   const existingKind = (nodeMap.get('kind', true) as any)?.value;
-                  nodeMap.set(
-                    'kind',
-                    doc.createNode(extraData.kind ?? existingKind ?? element.data.topoViewerRole ?? 'default-kind')
-                  );
-
                   const existingImage = (nodeMap.get('image', true) as any)?.value;
-                  nodeMap.set(
-                    'image',
-                    doc.createNode(extraData.image ?? existingImage ?? 'default-image')
-                  );
+                  const existingType = (nodeMap.get('type', true) as any)?.value;
 
-                  if (extraData.type || nodeMap.has('type')) {
-                    const existingType = (nodeMap.get('type', true) as any)?.value;
-                    const typeVal = extraData.type ?? existingType;
-                    if (typeVal !== undefined) {
-                      nodeMap.set('type', doc.createNode(typeVal));
-                    }
+                  const groupName = extraData.group || (element.parent ? element.parent.split(':')[0] : undefined) || (nodeMap.get('group', true) as any)?.value;
+                  const desiredKind = extraData.kind ?? existingKind ?? element.data.topoViewerRole;
+                  const desiredImage = extraData.image ?? existingImage;
+                  const desiredType = extraData.type ?? existingType;
+
+                  const inherit = this.resolveNodeConfig(topoObj, { group: groupName });
+
+                  if (groupName) {
+                    nodeMap.set('group', doc.createNode(groupName));
+                  } else {
+                    nodeMap.delete('group');
+                  }
+
+                  if (desiredKind && desiredKind !== inherit.kind) {
+                    nodeMap.set('kind', doc.createNode(desiredKind));
+                  } else {
+                    nodeMap.delete('kind');
+                  }
+
+                  if (desiredImage && desiredImage !== inherit.image) {
+                    nodeMap.set('image', doc.createNode(desiredImage));
+                  } else {
+                    nodeMap.delete('image');
+                  }
+
+                  if (desiredType !== undefined && desiredType !== inherit.type) {
+                    nodeMap.set('type', doc.createNode(desiredType));
+                  } else {
+                    nodeMap.delete('type');
                   }
 
                   // nodeYaml.set('startup-config', doc.createNode('configs/srl.cfg'));
@@ -864,6 +913,8 @@ topology:
               }
               const yamlNodes: YAML.YAMLMap = nodesMaybe;
 
+              const topoObj = doc.toJS() as ClabTopology;
+
               // Iterate through payload nodes to add/update nodes in YAML.
               payloadParsed
                 .filter(el => el.group === 'nodes' && el.data.topoViewerRole !== 'group')
@@ -883,23 +934,38 @@ topology:
 
                   // Update the node's core properties while preserving existing values.
                   const existingKind = (nodeMap.get('kind', true) as any)?.value;
-                  nodeMap.set(
-                    'kind',
-                    doc.createNode(extraData.kind ?? existingKind ?? element.data.topoViewerRole ?? 'default-kind')
-                  );
-
                   const existingImage = (nodeMap.get('image', true) as any)?.value;
-                  nodeMap.set(
-                    'image',
-                    doc.createNode(extraData.image ?? existingImage ?? 'default-image')
-                  );
+                  const existingType = (nodeMap.get('type', true) as any)?.value;
 
-                  if (extraData.type || nodeMap.has('type')) {
-                    const existingType = (nodeMap.get('type', true) as any)?.value;
-                    const typeVal = extraData.type ?? existingType;
-                    if (typeVal !== undefined) {
-                      nodeMap.set('type', doc.createNode(typeVal));
-                    }
+                  const groupName = extraData.group || (element.parent ? element.parent.split(':')[0] : undefined) || (nodeMap.get('group', true) as any)?.value;
+                  const desiredKind = extraData.kind ?? existingKind ?? element.data.topoViewerRole;
+                  const desiredImage = extraData.image ?? existingImage;
+                  const desiredType = extraData.type ?? existingType;
+
+                  const inherit = this.resolveNodeConfig(topoObj, { group: groupName });
+
+                  if (groupName) {
+                    nodeMap.set('group', doc.createNode(groupName));
+                  } else {
+                    nodeMap.delete('group');
+                  }
+
+                  if (desiredKind && desiredKind !== inherit.kind) {
+                    nodeMap.set('kind', doc.createNode(desiredKind));
+                  } else {
+                    nodeMap.delete('kind');
+                  }
+
+                  if (desiredImage && desiredImage !== inherit.image) {
+                    nodeMap.set('image', doc.createNode(desiredImage));
+                  } else {
+                    nodeMap.delete('image');
+                  }
+
+                  if (desiredType !== undefined && desiredType !== inherit.type) {
+                    nodeMap.set('type', doc.createNode(desiredType));
+                  } else {
+                    nodeMap.delete('type');
                   }
 
                   // nodeYaml.set('startup-config', doc.createNode('configs/srl.cfg'));

--- a/src/topoViewerEditor/webview-ui/managerViewportPanels.ts
+++ b/src/topoViewerEditor/webview-ui/managerViewportPanels.ts
@@ -127,7 +127,7 @@ export class ManagerViewportPanels {
     // Set the node image in the editor based on YAML data or fallback.
     const panelNodeEditorImageLabel = document.getElementById('panel-node-editor-image') as HTMLInputElement;
     if (panelNodeEditorImageLabel) {
-      panelNodeEditorImageLabel.value = extraData.image || 'default-image';
+      panelNodeEditorImageLabel.value = extraData.image ?? '';
     }
 
     // Set the node type in the editor.

--- a/test/unit/topoViewerEditor/inheritGroupSave.test.ts
+++ b/test/unit/topoViewerEditor/inheritGroupSave.test.ts
@@ -1,0 +1,197 @@
+/* eslint-env mocha */
+/* global describe, it, after, beforeEach, __dirname */
+import { expect } from 'chai';
+import sinon from 'sinon';
+import Module from 'module';
+import path from 'path';
+import * as fs from 'fs';
+import * as YAML from 'yaml';
+import { TopoViewerEditor } from '../../../src/topoViewerEditor/backend/topoViewerEditorWebUiFacade';
+const vscodeStub = require('../../helpers/vscode-stub');
+
+const originalResolve = (Module as any)._resolveFilename;
+(Module as any)._resolveFilename = function (request: string, parent: any, isMain: boolean, options: any) {
+  if (request === 'vscode') {
+    return path.join(__dirname, '..', '..', 'helpers', 'vscode-stub.js');
+  }
+  if (request.endsWith('commands/index')) {
+    return path.join(__dirname, '..', '..', '..', 'src', 'commands', 'index.js');
+  }
+  return originalResolve.call(this, request, parent, isMain, options);
+};
+
+const sampleYaml = `
+name: asd
+topology:
+  defaults:
+    kind: nokia_srsim
+    image: ghcr.io/nokia/srlinuxssss
+
+  groups:
+    spines:
+      type: sr-1
+
+  nodes:
+    srl1:
+      kind: nokia_srlinux
+      image: ghcr.io/nokia/srlinux:latest
+      type: ixrd1
+      labels:
+        graph-posX: "65"
+        graph-posY: "25"
+        graph-icon: router
+        graph-geoCoordinateLat: "49.329603962585516"
+        graph-geoCoordinateLng: "9.731229905076532"
+        graph-groupLabelPos: bottom-center
+    srl2:
+      group: spines
+      labels:
+        graph-posX: "165"
+        graph-posY: "25"
+        graph-icon: router
+        graph-geoCoordinateLat: "48.964876032177635"
+        graph-geoCoordinateLng: "9.481706542244165"
+        graph-groupLabelPos: bottom-center
+    nodeId-3:
+      group: spines
+      labels:
+        graph-posX: "155"
+        graph-posY: "105"
+        graph-icon: pe
+        graph-groupLabelPos: bottom-center
+        graph-geoCoordinateLat: "49.868844033546026"
+        graph-geoCoordinateLng: "10.086825736187491"
+
+  links:
+    - endpoints: [ srl1:e1-1, srl2:e1-1 ]
+    - endpoints: [ nodeId-3:e1-1, srl2:e1-2 ]
+`;
+
+describe('TopoViewerEditor group inheritance save', () => {
+  after(() => {
+    (Module as any)._resolveFilename = originalResolve;
+  });
+
+  beforeEach(() => {
+    sinon.restore();
+    vscodeStub.workspace.createFileSystemWatcher = () => ({
+      onDidChange: () => {},
+      dispose: () => {},
+    });
+    vscodeStub.workspace.onDidSaveTextDocument = () => ({ dispose: () => {} });
+  });
+
+  it('omits inherited attributes when saving', async () => {
+    sinon.stub(fs.promises, 'readFile').resolves(sampleYaml as any);
+    sinon.stub(fs.promises, 'mkdir').resolves();
+
+    let writtenYaml = '';
+    sinon.stub(fs.promises, 'writeFile').callsFake(async (_p, data) => {
+      writtenYaml = data as string;
+    });
+
+    let messageHandler: any = null;
+    const panelStub = {
+      webview: {
+        asWebviewUri: (u: any) => u,
+        html: '',
+        postMessage: sinon.spy(),
+        onDidReceiveMessage: (cb: any) => { messageHandler = cb; },
+      },
+      onDidDispose: () => {},
+      reveal: () => {},
+    };
+    sinon.stub(vscodeStub.window, 'createWebviewPanel').returns(panelStub as any);
+
+    const context = { extensionUri: vscodeStub.Uri.file('/ext'), subscriptions: [] } as any;
+    const editor = new TopoViewerEditor(context);
+    editor.lastYamlFilePath = '/tmp/test.clab.yml';
+
+    sinon.stub((editor as any).adaptor, 'clabYamlToCytoscapeElements').returns([]);
+    sinon.stub((editor as any).adaptor, 'generateStaticAssetUris').returns({ css: '', js: '', images: '' });
+    sinon.stub((editor as any).adaptor, 'createFolderAndWriteJson').callsFake(async (...args: any[]) => {
+      const yamlStr = args[3] as string;
+      (editor as any).adaptor.currentClabDoc = YAML.parseDocument(yamlStr);
+      return [] as any;
+    });
+    sinon.stub(editor as any, 'validateYaml').resolves(true);
+
+    await editor.createWebviewPanel(context, vscodeStub.Uri.file('/tmp/test.clab.yml'), 'test');
+
+    const payload = JSON.stringify([
+      {
+        group: 'nodes',
+        data: {
+          id: 'srl1',
+          name: 'srl1',
+          topoViewerRole: 'router',
+          extraData: {
+            group: '',
+            kind: 'nokia_srlinux',
+            image: 'ghcr.io/nokia/srlinux:latest',
+            type: 'ixrd1',
+            labels: {},
+          },
+        },
+        position: { x: 65, y: 25 },
+      },
+      {
+        group: 'nodes',
+        data: {
+          id: 'srl2',
+          name: 'srl2',
+          topoViewerRole: 'router',
+          extraData: {
+            group: 'spines',
+            kind: 'nokia_srsim',
+            image: 'ghcr.io/nokia/srlinuxssss',
+            type: 'sr-1',
+            labels: {},
+          },
+        },
+        position: { x: 165, y: 25 },
+      },
+      {
+        group: 'nodes',
+        data: {
+          id: 'nodeId-3',
+          name: 'nodeId-3',
+          topoViewerRole: 'pe',
+          extraData: {
+            group: 'spines',
+            kind: 'nokia_srsim',
+            image: 'ghcr.io/nokia/srlinuxssss',
+            type: 'sr-1',
+            labels: {},
+          },
+        },
+        position: { x: 155, y: 105 },
+      },
+      { group: 'edges', data: { endpoints: ['srl1:e1-1', 'srl2:e1-1'] } },
+      { group: 'edges', data: { endpoints: ['nodeId-3:e1-1', 'srl2:e1-2'] } },
+    ]);
+    if (messageHandler) {
+      await messageHandler({ type: 'POST', requestId: '1', endpointName: 'topo-editor-viewport-save', payload });
+    }
+
+    const saved = YAML.parse(writtenYaml) as any;
+    const n1 = saved.topology.nodes.srl1;
+    const n2 = saved.topology.nodes.srl2;
+    const n3 = saved.topology.nodes['nodeId-3'];
+
+    expect(n1.group).to.equal(undefined);
+    expect(n1.kind).to.equal('nokia_srlinux');
+    expect(n1.image).to.equal('ghcr.io/nokia/srlinux:latest');
+    expect(n1.type).to.equal('ixrd1');
+
+    expect(n2.group).to.equal('spines');
+    expect(n2.kind).to.equal(undefined);
+    expect(n2.image).to.equal(undefined);
+    expect(n2.type).to.equal(undefined);
+
+    expect(n3.group).to.equal('spines');
+    expect(n3.kind).to.equal(undefined);
+    expect(n3.image).to.equal(undefined);
+    expect(n3.type).to.equal(undefined);
+  });
+});


### PR DESCRIPTION
Ausführung-01:

- Implement support for [Containerlab topology `groups`](https://containerlab.dev/manual/topo-def-file/#groups) as specified in the official schema.

https://github.com/user-attachments/assets/15901c30-40fa-4947-a618-5de414b5689d

Ausführung-02:

- The `group` definitions created via the TopoEditor graph were previously stored under each node’s `labels` section and under node section
- The `group` under node section create conflicts with the new Containerlab group schema, which expects `group` under node section is to be defined to called `groups` definition in top-level section in the topology file.
- 
https://github.com/user-attachments/assets/3c385d59-3669-40a1-89e3-5d69696df263


