### PR TITLE
Sanitize the container name for wireshark VNC

### DIFF
--- a/src/commands/capture.ts
+++ b/src/commands/capture.ts
@@ -255,8 +255,9 @@ export async function captureEdgesharkVNC(
   }
 
   const port = await utils.getFreePort()
+  const ctrName = utils.sanitize(`clab_vsc_ws-${node.parentName}_${node.name}-${Date.now()}`)
   const containerId = await new Promise<string>((resolve, reject) => {
-    const command = `docker run -d --rm --pull ${dockerPullPolicy} -p 127.0.0.1:${port}:5800 ${edgesharkNetwork} ${volumeMount} ${darkModeSetting} -e PACKETFLIX_LINK="${modifiedPacketflixUri}" ${extraDockerArgs} --name clab_vsc_ws-${node.parentName}_${node.name}-${Date.now()} ${dockerImage}`;
+    const command = `docker run -d --rm --pull ${dockerPullPolicy} -p 127.0.0.1:${port}:5800 ${edgesharkNetwork} ${volumeMount} ${darkModeSetting} -e PACKETFLIX_LINK="${modifiedPacketflixUri}" ${extraDockerArgs} --name ${ctrName} ${dockerImage}`;
     exec(command, { encoding: 'utf-8' }, (err, stdout, stderr) => {
       if (err) {
         vscode.window.showErrorMessage(`Starting Wireshark: ${stderr}`);

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -430,3 +430,41 @@ export async function getSelectedLabNode(node?: ClabLabTreeNode): Promise<ClabLa
 
   return undefined;
 }
+
+// Sanitizes a string to a Docker-safe container name.
+// Rules: only [A-Za-z0-9_.-], must start with alnum, no trailing '.'/'-'.
+export function sanitize(
+  raw: string,
+  { maxLen = 128, lower = false }: { maxLen?: number; lower?: boolean } = {}
+): string {
+  if (!raw) return "container";
+
+  const allowed = /[A-Za-z0-9_.-]/;
+  let out = "";
+  let lastDash = false;
+
+  for (const ch of raw) {
+    if (allowed.test(ch) && ch !== "/") { // '/' is not allowed in --name
+      out += ch;
+      lastDash = false;
+    } else {
+      if (!lastDash) {
+        out += "-";
+        lastDash = true;
+      }
+    }
+  }
+
+  // Trim leading/trailing separators not allowed at ends
+  out = out.replace(/^[\-.]+/, "").replace(/[\-.]+$/, "");
+
+  // Must start with alphanumeric
+  if (!out || !/^[A-Za-z0-9]/.test(out)) out = `c-${out}`;
+
+  // Enforce length and avoid bad trailing chars after cut
+  if (out.length > maxLen) out = out.slice(0, maxLen);
+  out = out.replace(/[\-.]+$/, "");
+  if (!out) out = "container";
+
+  return lower ? out.toLowerCase() : out;
+}


### PR DESCRIPTION
When using SR-SIM/SROS with interface in format as `1/1/c1/1`, docker run doesn't like this in the `--name` flag for when we do a VNC pcap.