### PR TITLE
selection del and shortcuts plus minor enhancements

### DIFF
--- a/src/topoViewer/templates/main.html
+++ b/src/topoViewer/templates/main.html
@@ -35,6 +35,8 @@
     {{PANEL_BULK_LINK}}
     {{WIRESHARK_MODAL}}
     {{UNIFIED_FLOATING_PANEL}}
+    {{CONFIRM_DIALOG}}
+    {{SHORTCUTS_MODAL}}
     {{SCRIPTS}}
   </div>
 

--- a/src/topoViewer/templates/main.html
+++ b/src/topoViewer/templates/main.html
@@ -20,7 +20,7 @@
 
     <div id="cy-leaflet" class="absolute inset-0 p-0 z-0 hidden"></div>
 
-    <div id="cy" class="absolute inset-0 p-0 z-10"></div>
+    <div id="cy" tabindex="0" class="absolute inset-0 p-0 z-10"></div>
 
     {{VIEWPORT_DRAWER_LAYOUT}}
     {{VIEWPORT_DRAWER_TOPOLOGY_OVERVIEW}}

--- a/src/topoViewer/templates/partials/confirm-dialog.html
+++ b/src/topoViewer/templates/partials/confirm-dialog.html
@@ -1,0 +1,318 @@
+<!-- Reusable Confirm Dialog -->
+<div id="confirm-dialog-backdrop" class="modal-backdrop" style="display: none;">
+  <div id="confirm-dialog" class="modal-content p-6 rounded-lg max-w-md">
+    <!-- Icon Container -->
+    <div id="confirm-dialog-icon" class="flex justify-center mb-4" style="display: none;">
+      <i id="confirm-dialog-icon-element" class="text-4xl"></i>
+    </div>
+    
+    <!-- Title -->
+    <h3 id="confirm-dialog-title" class="text-lg font-semibold text-center mb-2">
+      Confirm Action
+    </h3>
+    
+    <!-- Message -->
+    <p id="confirm-dialog-message" class="text-sm text-center mb-6 text-secondary">
+      Are you sure you want to proceed?
+    </p>
+    
+    <!-- Buttons Container -->
+    <div id="confirm-dialog-buttons" class="flex justify-center gap-3">
+      <button id="confirm-dialog-cancel" class="btn btn-secondary">
+        Cancel
+      </button>
+      <button id="confirm-dialog-confirm" class="btn btn-primary">
+        Confirm
+      </button>
+    </div>
+  </div>
+</div>
+
+<script>
+(function() {
+  'use strict';
+
+  let confirmResolve = null;
+  let isDialogOpen = false;
+
+  const backdrop = document.getElementById('confirm-dialog-backdrop');
+  const dialog = document.getElementById('confirm-dialog');
+  const iconContainer = document.getElementById('confirm-dialog-icon');
+  const iconElement = document.getElementById('confirm-dialog-icon-element');
+  const titleElement = document.getElementById('confirm-dialog-title');
+  const messageElement = document.getElementById('confirm-dialog-message');
+  const cancelButton = document.getElementById('confirm-dialog-cancel');
+  const confirmButton = document.getElementById('confirm-dialog-confirm');
+
+  function closeDialog(result) {
+    if (!isDialogOpen) return;
+    
+    isDialogOpen = false;
+    backdrop.style.display = 'none';
+    document.removeEventListener('keydown', handleKeydown);
+    
+    if (confirmResolve) {
+      confirmResolve(result);
+      confirmResolve = null;
+    }
+  }
+
+  function handleKeydown(event) {
+    if (!isDialogOpen) return;
+    
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      closeDialog(false);
+    } else if (event.key === 'Enter') {
+      event.preventDefault();
+      closeDialog(true);
+    }
+  }
+
+  // Show confirmation dialog
+  window.showConfirmDialog = function(options = {}) {
+    return new Promise((resolve) => {
+      if (isDialogOpen) {
+        resolve(false);
+        return;
+      }
+      
+      confirmResolve = resolve;
+      isDialogOpen = true;
+
+      // Set title
+      titleElement.textContent = options.title || 'Confirm Action';
+      
+      // Set message
+      messageElement.textContent = options.message || 'Are you sure you want to proceed?';
+      
+      // Set icon
+      if (options.icon) {
+        iconElement.className = `text-4xl ${options.icon}`;
+        iconContainer.style.display = 'flex';
+      } else {
+        iconContainer.style.display = 'none';
+      }
+      
+      // Set button texts and styles
+      const cancelText = options.cancelText || 'Cancel';
+      const confirmText = options.confirmText || 'Confirm';
+      const confirmStyle = options.confirmStyle || 'btn-primary';
+      
+      cancelButton.textContent = cancelText;
+      confirmButton.textContent = confirmText;
+      
+      // Reset button classes and apply new style
+      confirmButton.className = `btn ${confirmStyle}`;
+      
+      // Show dialog
+      backdrop.style.display = 'flex';
+      
+      // Focus default button
+      if (options.focusCancel) {
+        cancelButton.focus();
+      } else {
+        confirmButton.focus();
+      }
+      
+      // Add keyboard listener
+      document.addEventListener('keydown', handleKeydown);
+    });
+  };
+
+  // Predefined dialog types for common actions
+  window.showDeleteConfirm = function(itemName, count = 1) {
+    const message = count > 1 
+      ? `Are you sure you want to delete ${count} selected items?`
+      : itemName 
+        ? `Are you sure you want to delete "${itemName}"?`
+        : 'Are you sure you want to delete this item?';
+        
+    return window.showConfirmDialog({
+      title: 'Confirm Deletion',
+      message: message,
+      icon: 'fas fa-exclamation-triangle text-yellow-500',
+      confirmText: 'Delete',
+      confirmStyle: 'btn-danger',
+      cancelText: 'Cancel (esc)',
+      focusCancel: true
+    });
+  };
+
+
+
+  window.showBulkActionConfirm = function(actionName, sourcePattern, targetPattern, estimatedCount = null) {
+    let message = `Create links between devices matching "${sourcePattern}" and "${targetPattern}"?`;
+    if (estimatedCount) {
+      message += ` This will create approximately ${estimatedCount} links.`;
+    }
+    
+    return window.showConfirmDialog({
+      title: `Confirm ${actionName}`,
+      message: message,
+      icon: 'fas fa-link text-blue-500',
+      confirmText: 'Create Links',
+      confirmStyle: 'btn-primary',
+      cancelText: 'Cancel (esc)'
+    });
+  };
+
+  // Event listeners for buttons
+  cancelButton.addEventListener('click', function(e) {
+    e.preventDefault();
+    e.stopPropagation();
+    closeDialog(false);
+  });
+
+  confirmButton.addEventListener('click', function(e) {
+    e.preventDefault();
+    e.stopPropagation();
+    closeDialog(true);
+  });
+
+  // Click outside to cancel
+  backdrop.addEventListener('click', function(e) {
+    if (e.target === backdrop) {
+      closeDialog(false);
+    }
+  });
+
+})();
+
+// Global panel keyboard handler for ESC/ENTER functionality
+(function() {
+  'use strict';
+
+  // Global keyboard handler for all panels
+  function handleGlobalPanelKeys(event) {
+    // Skip if confirm dialog is open
+    const confirmBackdrop = document.getElementById('confirm-dialog-backdrop');
+    if (confirmBackdrop && confirmBackdrop.style.display !== 'none') {
+      return;
+    }
+
+    // Find currently visible panel
+    const visiblePanel = findVisiblePanel();
+    if (!visiblePanel) {
+      return;
+    }
+    
+    if (event.key === 'Escape') {
+      // ESC always closes the panel
+      event.preventDefault();
+      closePanel(visiblePanel);
+    } else if (event.key === 'Enter') {
+      // ENTER works for form submission
+      event.preventDefault();
+      triggerPrimaryAction(visiblePanel);
+    }
+  }
+
+  // Find the currently visible panel
+  function findVisiblePanel() {
+    const panelSelectors = [
+      '#panel-bulk-link',
+      '#panel-node-editor-parent', 
+      '#panel-topoviewer-about',
+      '#panel-network-editor',
+      '#panel-node-editor',
+      '#panel-link-editor',
+      '#panel-link',
+      '#panel-node',
+      '#viewport-drawer-topology-overview',
+      '#viewport-drawer-capture-sceenshoot',
+      '#viewport-drawer-layout',
+      '#shortcuts-panel'
+    ];
+
+    for (const selector of panelSelectors) {
+      const panel = document.querySelector(selector);
+      if (panel && panel.style.display === 'block') {
+        return panel;
+      }
+    }
+    return null;
+  }
+
+  // Close a panel
+  function closePanel(panel) {
+    panel.style.display = 'none';
+    
+    // For viewport drawers, also hide all other drawers
+    if (panel.id.startsWith('viewport-drawer-')) {
+      const viewportDrawers = document.getElementsByClassName('viewport-drawer');
+      for (let i = 0; i < viewportDrawers.length; i++) {
+        viewportDrawers[i].style.display = 'none';
+      }
+    }
+  }
+
+  // Trigger the primary action button in a panel
+  function triggerPrimaryAction(panel) {
+    console.log('triggerPrimaryAction called for panel:', panel.id);
+    
+    // First try specific known button IDs for each panel
+    const panelSpecificButtons = {
+      'panel-bulk-link': '#bulk-link-apply',
+      'panel-node-editor': '#panel-node-editor-save-button',
+      'panel-node-editor-parent': 'button[onclick*="nodeParentPropertiesUpdate()"]',
+      'panel-link-editor': '#panel-link-editor-save-button',
+      'panel-network-editor': 'button[onclick*="Apply"]'
+    };
+
+    const panelId = panel.id;
+    if (panelSpecificButtons[panelId]) {
+      const selector = panelSpecificButtons[panelId];
+      const button = panel.querySelector(selector);
+      console.log('Specific selector for', panelId, ':', selector);
+      console.log('Found button:', button);
+      if (button && !button.disabled && button.style.display !== 'none') {
+        console.log('Clicking specific button:', button.textContent.trim());
+        button.click();
+        return;
+      }
+    }
+
+    // Look for common primary action buttons (in order of preference)
+    const primaryButtonSelectors = [
+      '.btn-primary:not([style*="display: none"])',
+      'button[id*="apply"]:not([style*="display: none"])',
+      'button[id*="save"]:not([style*="display: none"])',
+      'button[id*="update"]:not([style*="display: none"])',
+      'button[onclick*="Apply"]:not([style*="display: none"])',
+      'button[onclick*="Update"]:not([style*="display: none"])', 
+      'button[onclick*="Save"]:not([style*="display: none"])',
+      'button[type="submit"]:not([style*="display: none"])'
+    ];
+
+    console.log('Trying fallback selectors...');
+    for (const selector of primaryButtonSelectors) {
+      const button = panel.querySelector(selector);
+      console.log('Selector:', selector, 'found:', button);
+      if (button && !button.disabled) {
+        console.log('Clicking fallback button:', button.textContent.trim());
+        button.click();
+        return;
+      }
+    }
+
+    // Final fallback: find any visible button that looks like a primary action
+    console.log('Trying final fallback...');
+    const buttons = panel.querySelectorAll('button:not(.btn-secondary):not(.btn-danger):not([id*="cancel"]):not([id*="close"])');
+    console.log('Final fallback buttons found:', buttons.length);
+    for (const button of buttons) {
+      console.log('Final fallback button:', button.textContent.trim(), 'disabled:', button.disabled, 'display:', button.style.display);
+      if (!button.disabled && button.style.display !== 'none') {
+        console.log('Clicking final fallback button:', button.textContent.trim());
+        button.click();
+        return;
+      }
+    }
+    console.log('No button found for ENTER action');
+  }
+
+  // Add global event listener
+  document.addEventListener('keydown', handleGlobalPanelKeys);
+
+})();
+</script>

--- a/src/topoViewer/templates/partials/navbar-buttons.html
+++ b/src/topoViewer/templates/partials/navbar-buttons.html
@@ -56,6 +56,15 @@
 </p>
 
 <p class="m-0 p-0">
+  <button id="viewport-shortcuts" title="Shortcuts" onclick="showShortcutsModal()"
+    class="btn-icon-hover-clean">
+    <span class="inline-flex items-center justify-center text-xl">
+      <i class="fa-solid fa-keyboard"></i>
+    </span>
+  </button>
+</p>
+
+<p class="m-0 p-0">
   <button id="viewport-about" title="About TopoViewer" onclick="showPanelAbout()"
     class="btn-icon-hover-clean">
     <span class="inline-flex items-center justify-center text-xl">

--- a/src/topoViewer/templates/partials/panel-bulk-link.html
+++ b/src/topoViewer/templates/partials/panel-bulk-link.html
@@ -54,11 +54,11 @@
   document.getElementById('bulk-link-cancel').addEventListener('click', () => {
     document.getElementById('panel-bulk-link').style.display = 'none';
   });
-  document.getElementById('bulk-link-apply').addEventListener('click', () => {
+  document.getElementById('bulk-link-apply').addEventListener('click', async () => {
     const source = document.getElementById('source-regex').value;
     const target = document.getElementById('target-regex').value;
     if (source && target) {
-      window.topologyWebviewController.bulkCreateLinks(source, target);
+      await window.topologyWebviewController.bulkCreateLinks(source, target);
       document.getElementById('panel-bulk-link').style.display = 'none';
     }
   });

--- a/src/topoViewer/templates/partials/panel-node-editor-parent.html
+++ b/src/topoViewer/templates/partials/panel-node-editor-parent.html
@@ -68,8 +68,7 @@
                 </div>
                 <div class="w-3/5 pl-2 pr-2">
                   <div class="relative" id="panel-node-editor-parent-label-dropdown">
-                    <button class="btn btn-small inline-flex items-center font-extralight"
-                            onclick="panelNodeEditorParentToggleDropdown()">
+                    <button class="btn btn-small inline-flex items-center font-extralight">
                       <span id="panel-node-editor-parent-label-dropdown-button-text">Select Position</span>
                       <span class="ml-2 font-extralight text-base">
                         <i class="fas fa-angle-down" aria-hidden="true"></i>
@@ -105,7 +104,10 @@
                   <label class="label text-right text-base font-semibold">Background</label>
                 </div>
                 <div class="w-3/5 pl-2 pr-2">
-                  <input type="color" class="input-field w-full h-8" id="panel-node-editor-parent-bg-color">
+                  <div class="flex items-center space-x-2">
+                    <input type="color" class="input-field h-8 w-8 cursor-pointer border border-gray-500" id="panel-node-editor-parent-bg-color">
+                    <input type="text" class="input-field text-base flex-1" id="panel-node-editor-parent-bg-color-hex" maxlength="7" placeholder="#RRGGBB">
+                  </div>
                 </div>
               </div>
             </div>
@@ -136,7 +138,10 @@
                   <label class="label text-right text-base font-semibold">Text Color</label>
                 </div>
                 <div class="w-3/5 pl-2 pr-2">
-                  <input type="color" class="input-field w-full h-8" id="panel-node-editor-parent-text-color">
+                  <div class="flex items-center space-x-2">
+                    <input type="color" class="input-field h-8 w-8 cursor-pointer border border-gray-500" id="panel-node-editor-parent-text-color">
+                    <input type="text" class="input-field text-base flex-1" id="panel-node-editor-parent-text-color-hex" maxlength="7" placeholder="#RRGGBB">
+                  </div>
                 </div>
               </div>
             </div>
@@ -155,7 +160,10 @@
                   <label class="label text-right text-base font-semibold">Border Color</label>
                 </div>
                 <div class="w-3/5 pl-2 pr-2">
-                  <input type="color" class="input-field w-full h-8" id="panel-node-editor-parent-border-color">
+                  <div class="flex items-center space-x-2">
+                    <input type="color" class="input-field h-8 w-8 cursor-pointer border border-gray-500" id="panel-node-editor-parent-border-color">
+                    <input type="text" class="input-field text-base flex-1" id="panel-node-editor-parent-border-color-hex" maxlength="7" placeholder="#RRGGBB">
+                  </div>
                 </div>
               </div>
             </div>
@@ -220,13 +228,10 @@
               <div class="w-3/5 pl-2 pr-2">
                 <div class="flex justify-end space-x-2">
                   <button class="btn btn-danger btn-small"
-                          id="panel-node-editor-parent-delete-button"
-                          onclick="nodeParentRemoval()">Remove</button>
+                          id="panel-node-editor-parent-delete-button">Remove</button>
                   <button class="btn btn-secondary btn-small"
-                          id="panel-node-editor-parent-close-button"
-                          onclick="nodeParentPropertiesUpdateClose()">Close</button>
-                  <button class="btn btn-primary btn-small"
-                          onclick="nodeParentPropertiesUpdate()">Update</button>
+                          id="panel-node-editor-parent-close-button">Close</button>
+                  <button class="btn btn-primary btn-small">Update</button>
                 </div>
               </div>
             </div>
@@ -238,16 +243,17 @@
   </div>
 </section>
 
-<script>
-  // Handle opacity slider
-  document.getElementById('panel-node-editor-parent-bg-opacity')?.addEventListener('input', (e) => {
-    const value = e.target.value;
-    document.getElementById('panel-node-editor-parent-bg-opacity-value').textContent = value + '%';
-  });
+<style>
+  input[type="color"] {
+    -webkit-appearance: none;
+    appearance: none;
+    padding: 0;
+  }
+  input[type="color"]::-webkit-color-swatch-wrapper {
+    padding: 0;
+  }
+  input[type="color"]::-webkit-color-swatch {
+    border: none;
+  }
+</style>
 
-  // Handle border radius slider
-  document.getElementById('panel-node-editor-parent-border-radius')?.addEventListener('input', (e) => {
-    const value = e.target.value;
-    document.getElementById('panel-node-editor-parent-border-radius-value').textContent = value + 'px';
-  });
-</script>

--- a/src/topoViewer/templates/partials/panel-topoviewer-about.html
+++ b/src/topoViewer/templates/partials/panel-topoviewer-about.html
@@ -7,42 +7,6 @@
       <div class="py-2">
         <article class="px-4 text-base max-h-[280px] overflow-y-auto">
           <section class="mb-4">
-            <p class="mt-2"><strong>Getting Started</strong></p>
-            <p class="text-sm">
-              TopoViewer provides two modes for working with Containerlab topologies:
-            </p>
-
-            <p class="mt-3"><strong>Viewer Mode</strong></p>
-            <p class="text-sm mb-2">
-              Explore and interact with deployed topologies. Visualize running labs and manage containers.
-            </p>
-            <ul class="list-disc list-inside text-sm">
-              <li><strong>Left-click:</strong> Select and view node/link details</li>
-              <li><strong>Right-click node:</strong> SSH, attach shell, view logs</li>
-              <li><strong>Right-click link:</strong> Capture packets with Wireshark</li>
-              <li><strong>Drag:</strong> Move nodes to organize layout</li>
-            </ul>
-
-            <p class="mt-3"><strong>Editor Mode</strong></p>
-            <p class="text-sm mb-2">
-              Create and modify topology files visually. Design your infrastructure with GUI.
-            </p>
-            <ul class="list-disc list-inside text-sm">
-              <li><strong>Shift + Click canvas:</strong> Add new node</li>
-              <li><strong>Shift + Click node:</strong> Start link creation</li>
-              <li><strong>Alt + Click:</strong> Delete node or link</li>
-              <li><strong>Right-click:</strong> Context menu for edit/delete</li>
-              <li><strong>Drag node to group:</strong> Auto-assign to group</li>
-            </ul>
-
-            <p class="mt-3"><strong>Tips</strong></p>
-            <ul class="list-disc list-inside text-sm">
-              <li>Use layout algorithms to auto-arrange topologies</li>
-              <li>Box selection to select multiple elements</li>
-              <li>Double-click text annotations to edit</li>
-              <li>Export topology as image from context menu</li>
-            </ul>
-
             <p class="mt-3"><strong>Original Author</strong></p>
             <p class="text-sm">
               TopoViewer was originally designed and developed by

--- a/src/topoViewer/templates/partials/shortcuts-modal.html
+++ b/src/topoViewer/templates/partials/shortcuts-modal.html
@@ -1,0 +1,98 @@
+<!-- Shortcuts Panel -->
+<aside class="panel viewport-drawer fixed top-[4.5rem] right-[1rem] w-80 z-[30] max-h-[calc(100vh-5rem)]" id="shortcuts-panel" style="display: none;">
+  <header class="panel-heading text-sm flex-shrink-0">
+    <i class="fas fa-keyboard mr-2"></i>Shortcuts & Interactions
+  </header>
+  
+  <div class="p-4 space-y-4 overflow-y-auto overflow-x-hidden flex-1 min-h-0" style="max-height: calc(100vh - 8rem); scrollbar-width: thin;">
+    <!-- Viewer Mode -->
+    <section>
+      <h4 class="text-sm font-semibold text-green-600 mb-2"><i class="fas fa-eye"></i> Viewer Mode</h4>
+      <div class="space-y-1 text-xs">
+        <div class="flex justify-between">
+          <span>Select node/link</span>
+          <kbd>Left Click</kbd>
+        </div>
+        <div class="flex justify-between">
+          <span>Node actions</span>
+          <kbd>Right Click</kbd>
+        </div>
+        <div class="flex justify-between">
+          <span>Capture packets</span>
+          <kbd>Right Click + Link</kbd>
+        </div>
+        <div class="flex justify-between">
+          <span>Move nodes</span>
+          <kbd>Drag</kbd>
+        </div>
+      </div>
+    </section>
+    
+    <!-- Editor Mode -->
+    <section>
+      <h4 class="text-sm font-semibold text-blue-600 mb-2"><i class="fas fa-edit"></i> Editor Mode</h4>
+      <div class="space-y-1 text-xs">
+        <div class="flex justify-between">
+          <span>Add node</span>
+          <kbd>Shift + Click</kbd>
+        </div>
+        <div class="flex justify-between">
+          <span>Create link</span>
+          <kbd>Shift + Node</kbd>
+        </div>
+        <div class="flex justify-between">
+          <span>Delete</span>
+          <kbd>Alt + Click</kbd>
+        </div>
+        <div class="flex justify-between">
+          <span>Context menu</span>
+          <kbd>Right Click</kbd>
+        </div>
+        <div class="flex justify-between">
+          <span>Select all</span>
+          <kbd>Ctrl + A</kbd>
+        </div>
+        <div class="flex justify-between">
+          <span>Create group (empty or from selection)</span>
+          <kbd>G</kbd>
+        </div>
+        <div class="flex justify-between">
+          <span>Delete selected</span>
+          <kbd>Del</kbd>
+        </div>
+      </div>
+    </section>
+    
+    <!-- Panel Controls -->
+    <section>
+      <h4 class="text-sm font-semibold text-purple-600 mb-2"><i class="fas fa-cog"></i> Panel Controls</h4>
+      <div class="space-y-1 text-xs">
+        <div class="flex justify-between">
+          <span>Close panel</span>
+          <kbd>Esc</kbd>
+        </div>
+        <div class="flex justify-between">
+          <span>Submit form</span>
+          <kbd>Enter</kbd>
+        </div>
+      </div>
+    </section>
+    
+    <!-- Tips -->
+    <section>
+      <h4 class="text-sm font-semibold text-orange-600 mb-2"><i class="fas fa-lightbulb"></i> Tips</h4>
+      <ul class="list-disc list-inside text-xs text-secondary space-y-1">
+        <li>Use layout algorithms to auto-arrange</li>
+        <li>Box Selection with <kbd>Shift</kbd> + <kbd>Click</kbd> and press <kbd>G</kbd> to group or <kbd>Del</kbd> to delete</li>
+        <li>Double-click any item to directly edit</li>
+        <li>Export as image from context menu</li>
+      </ul>
+    </section>
+  </div>
+</aside>
+
+<script>
+window.showShortcutsModal = function() {
+  document.getElementById('shortcuts-panel').style.display = 'block';
+};
+</script>

--- a/src/topoViewer/templates/partials/shortcuts-modal.html
+++ b/src/topoViewer/templates/partials/shortcuts-modal.html
@@ -1,14 +1,14 @@
 <!-- Shortcuts Panel -->
 <aside class="panel viewport-drawer fixed top-[4.5rem] right-[1rem] w-80 z-[30] max-h-[calc(100vh-5rem)]" id="shortcuts-panel" style="display: none;">
-  <header class="panel-heading text-sm flex-shrink-0">
+  <header class="panel-heading flex-shrink-0">
     <i class="fas fa-keyboard mr-2"></i>Shortcuts & Interactions
   </header>
   
   <div class="p-4 space-y-4 overflow-y-auto overflow-x-hidden flex-1 min-h-0" style="max-height: calc(100vh - 8rem); scrollbar-width: thin;">
     <!-- Viewer Mode -->
     <section>
-      <h4 class="text-sm font-semibold text-green-600 mb-2"><i class="fas fa-eye"></i> Viewer Mode</h4>
-      <div class="space-y-1 text-xs">
+      <h4 class="font-semibold text-green-600 mb-2"><i class="fas fa-eye"></i> Viewer Mode</h4>
+      <div class="space-y-1">
         <div class="flex justify-between">
           <span>Select node/link</span>
           <kbd>Left Click</kbd>
@@ -30,8 +30,8 @@
     
     <!-- Editor Mode -->
     <section>
-      <h4 class="text-sm font-semibold text-blue-600 mb-2"><i class="fas fa-edit"></i> Editor Mode</h4>
-      <div class="space-y-1 text-xs">
+      <h4 class="font-semibold text-blue-600 mb-2"><i class="fas fa-edit"></i> Editor Mode</h4>
+      <div class="space-y-1">
         <div class="flex justify-between">
           <span>Add node</span>
           <kbd>Shift + Click</kbd>
@@ -53,7 +53,7 @@
           <kbd>Ctrl + A</kbd>
         </div>
         <div class="flex justify-between">
-          <span>Create group (empty or from selection)</span>
+         <span>Create group (also via selection)</span>
           <kbd>G</kbd>
         </div>
         <div class="flex justify-between">
@@ -65,8 +65,8 @@
     
     <!-- Panel Controls -->
     <section>
-      <h4 class="text-sm font-semibold text-purple-600 mb-2"><i class="fas fa-cog"></i> Panel Controls</h4>
-      <div class="space-y-1 text-xs">
+      <h4 class="font-semibold text-purple-600 mb-2"><i class="fas fa-cog"></i> Panel Controls</h4>
+      <div class="space-y-1">
         <div class="flex justify-between">
           <span>Close panel</span>
           <kbd>Esc</kbd>
@@ -80,8 +80,8 @@
     
     <!-- Tips -->
     <section>
-      <h4 class="text-sm font-semibold text-orange-600 mb-2"><i class="fas fa-lightbulb"></i> Tips</h4>
-      <ul class="list-disc list-inside text-xs text-secondary space-y-1">
+      <h4 class="font-semibold text-orange-600 mb-2"><i class="fas fa-lightbulb"></i> Tips</h4>
+      <ul class="list-disc list-inside text-secondary space-y-1">
         <li>Use layout algorithms to auto-arrange</li>
         <li>Box Selection with <kbd>Shift</kbd> + <kbd>Click</kbd> and press <kbd>G</kbd> to group or <kbd>Del</kbd> to delete</li>
         <li>Double-click any item to directly edit</li>

--- a/src/topoViewer/webview-ui/managerCytoscapeBaseStyles.ts
+++ b/src/topoViewer/webview-ui/managerCytoscapeBaseStyles.ts
@@ -133,13 +133,9 @@ const cytoscapeStylesBase: any[] = [
   },
   {
     selector: 'node:selected',
-    style: {
-      'border-width': '1.5px',
-      'border-color': '#282828',
-      'border-opacity': '0.5',
-      'background-color': '#77828C',
-      'text-outline-color': '#282828'
-    }
+  },
+  {
+    selector: 'edge:selected',
   },
   // Status indicator nodes
   {
@@ -244,7 +240,6 @@ const cytoscapeStylesBase: any[] = [
       'text-outline-color': '#282828'
     }
   },
-  { selector: 'edge.filtered', style: { opacity: '0.3' } },
   {
     selector: '.spf',
     style: {
@@ -444,6 +439,11 @@ cytoscapeStylesBase.splice(insertIndex, 0, ...roleStyles, ...freeTextStyles);
  * When `theme` is "light" group nodes appear darker with higher opacity.
  */
 export function getCytoscapeStyles(theme: 'light' | 'dark') {
+  const rootStyle = window.getComputedStyle(document.documentElement);
+  const selectionColor = rootStyle.getPropertyValue('--vscode-focusBorder').trim();
+  const selectionBoxColor = rootStyle.getPropertyValue('--vscode-list-focusBackground').trim();
+  const selectionBoxBorderColor = rootStyle.getPropertyValue('--vscode-focusBorder').trim();
+
   const styles = cytoscapeStylesBase.map((def: any) => {
     const clone: any = { selector: def.selector, style: { ...(def.style || {}) } };
     if (def.selector === 'node[topoViewerRole="group"]') {
@@ -457,6 +457,37 @@ export function getCytoscapeStyles(theme: 'light' | 'dark') {
         clone.style['background-opacity'] = '0.2';
       }
     }
+
+    // Theme-aware selection styling
+    if (def.selector === 'node:selected') {
+      clone.style['border-color'] = selectionColor;
+      clone.style['overlay-color'] = selectionColor;
+      clone.style['border-width'] = '3px';
+      clone.style['border-opacity'] = '1';
+      clone.style['border-style'] = 'solid';
+      clone.style['overlay-opacity'] = '0.3';
+      clone.style['overlay-padding'] = '3px';
+    }
+
+    if (def.selector === 'edge:selected') {
+      clone.style['line-color'] = selectionColor;
+      clone.style['target-arrow-color'] = selectionColor;
+      clone.style['source-arrow-color'] = selectionColor;
+      clone.style['overlay-color'] = selectionColor;
+      clone.style['overlay-opacity'] = '0.2';
+      clone.style['overlay-padding'] = '6px';
+      clone.style['width'] = '4px';
+      clone.style['opacity'] = '1';
+      clone.style['z-index'] = '10';
+    }
+
+    // Theme-aware selection box (for multi-select)
+    if (def.selector === 'core') {
+      clone.style['selection-box-color'] = selectionBoxColor;
+      clone.style['selection-box-border-color'] = selectionBoxBorderColor;
+      clone.style['selection-box-opacity'] = '0.5';
+    }
+
     return clone;
   });
 

--- a/src/topoViewer/webview-ui/managerCytoscapeBaseStyles.ts
+++ b/src/topoViewer/webview-ui/managerCytoscapeBaseStyles.ts
@@ -491,6 +491,26 @@ export function getCytoscapeStyles(theme: 'light' | 'dark') {
     return clone;
   });
 
+  // Add font size scaling based on VS Code theme
+  const bodyStyle = window.getComputedStyle(document.body);
+  const basePx = parseFloat(bodyStyle.fontSize) || 12;
+  const scaleFactor = basePx / 12;
+
+  styles.forEach((def) => {
+    const s = def.style;
+    if (s) {
+      ['font-size', 'min-zoomed-font-size'].forEach((key) => {
+        if (s[key] !== undefined) {
+          const valStr = s[key].toString();
+          const val = parseFloat(valStr);
+          if (!isNaN(val)) {
+            s[key] = `${Math.round(val * scaleFactor)}px`;
+          }
+        }
+      });
+    }
+  });
+
   const vis = topoViewerState.linkEndpointVisibility;
   if (typeof vis === 'boolean' && !vis) {
     const edgeStyle = styles.find((s: any) => s.selector === 'edge');

--- a/src/topoViewer/webview-ui/managerGroupManagement.ts
+++ b/src/topoViewer/webview-ui/managerGroupManagement.ts
@@ -133,41 +133,7 @@ export class ManagerGroupManagement {
     };
     this.groupStyleManager.updateGroupStyle(newParentId, defaultStyle);
 
-    const panel = document.getElementById('panel-node-editor-parent');
-    if (panel) {
-      panel.style.display = 'block';
-      const groupIdEl = document.getElementById('panel-node-editor-parent-graph-group-id');
-      const groupEl = document.getElementById('panel-node-editor-parent-graph-group') as HTMLInputElement;
-      const levelEl = document.getElementById('panel-node-editor-parent-graph-level') as HTMLInputElement;
-      const bgColorEl = document.getElementById('panel-node-editor-parent-bg-color') as HTMLInputElement;
-      const bgOpacityEl = document.getElementById('panel-node-editor-parent-bg-opacity') as HTMLInputElement;
-      const borderColorEl = document.getElementById('panel-node-editor-parent-border-color') as HTMLInputElement;
-      const borderWidthEl = document.getElementById('panel-node-editor-parent-border-width') as HTMLInputElement;
-      const borderStyleEl = document.getElementById('panel-node-editor-parent-border-style') as HTMLSelectElement;
-      const borderRadiusEl = document.getElementById('panel-node-editor-parent-border-radius') as HTMLInputElement;
-      const textColorEl = document.getElementById('panel-node-editor-parent-text-color') as HTMLInputElement;
-
-      if (groupIdEl) groupIdEl.textContent = newParentId;
-      if (groupEl) groupEl.value = newParentId.split(':')[0];
-      if (levelEl) levelEl.value = newParentId.split(':')[1];
-
-      // Set the default style values in the inputs
-      if (bgColorEl) bgColorEl.value = '#d9d9d9';
-      if (bgOpacityEl) {
-        bgOpacityEl.value = '20';
-        const opacityValueEl = document.getElementById('panel-node-editor-parent-bg-opacity-value');
-        if (opacityValueEl) opacityValueEl.textContent = '20%';
-      }
-      if (borderColorEl) borderColorEl.value = '#dddddd';
-      if (borderWidthEl) borderWidthEl.value = '0.5';
-      if (borderStyleEl) borderStyleEl.value = 'solid';
-      if (borderRadiusEl) {
-        borderRadiusEl.value = '0';
-        const radiusValueEl = document.getElementById('panel-node-editor-parent-border-radius-value');
-        if (radiusValueEl) radiusValueEl.textContent = '0px';
-      }
-      if (textColorEl) textColorEl.value = '#ebecf0';
-    }
+    this.showGroupEditor(newParentId);
 
     return newParentId;
   }

--- a/src/topoViewer/webview-ui/managerGroupManagement.ts
+++ b/src/topoViewer/webview-ui/managerGroupManagement.ts
@@ -377,6 +377,62 @@ export class ManagerGroupManagement {
         if (radiusValueEl) radiusValueEl.textContent = radius + 'px';
       }
       if (textColorEl) textColorEl.value = style?.color || '#ebecf0';
+
+      // Attach event listeners for auto-update
+      const autoUpdateGroup = () => this.nodeParentPropertiesUpdate();
+
+      // Format range display values
+      const formatRangeValue = (el: HTMLInputElement, value: string) => {
+        if (el.id.includes('opacity')) return value + '%';
+        if (el.dataset.unit) return value + el.dataset.unit;
+        return value + 'px';
+      };
+
+      // Attach listeners to all relevant inputs
+      panel.querySelectorAll('input[type="range"], input[type="number"], input[type="color"], input[type="text"][id$="-hex"], select').forEach(el => {
+        const inputEl = el as HTMLInputElement | HTMLSelectElement;
+        const isRange = inputEl instanceof HTMLInputElement && inputEl.type === 'range';
+        const isColor = inputEl instanceof HTMLInputElement && inputEl.type === 'color';
+        const isHex = inputEl instanceof HTMLInputElement && inputEl.type === 'text' && inputEl.id.endsWith('-hex');
+        const eventType = isRange || isColor || isHex ? 'input' : 'change';
+
+        const onChange = () => {
+          if (isRange) {
+            const valueEl = panel.querySelector('#' + inputEl.id + '-value') as HTMLElement;
+            if (valueEl) valueEl.textContent = formatRangeValue(inputEl, inputEl.value);
+          } else if (isColor) {
+            const hexId = inputEl.id.replace('-color', '-color-hex');
+            const hex = document.getElementById(hexId) as HTMLInputElement;
+            if (hex) hex.value = inputEl.value;
+          } else if (isHex) {
+            const val = inputEl.value.toUpperCase();
+            if (/^#[0-9A-F]{6}$/.test(val)) {
+              const colorId = inputEl.id.replace('-hex', '');
+              const color = document.getElementById(colorId) as HTMLInputElement;
+              if (color) color.value = val;
+            }
+          }
+          autoUpdateGroup();
+        };
+
+        inputEl.addEventListener(eventType, onChange);
+        if (isRange || isColor) onChange(); // Initial update
+      });
+
+      // Attach button click handlers
+      const deleteButton = document.getElementById('panel-node-editor-parent-delete-button');
+      if (deleteButton) deleteButton.addEventListener('click', () => this.nodeParentRemoval());
+
+      const closeButton = document.getElementById('panel-node-editor-parent-close-button');
+      if (closeButton) closeButton.addEventListener('click', () => this.nodeParentPropertiesUpdateClose());
+
+      const updateButton = panel.querySelector('.btn-primary') as HTMLButtonElement;
+      if (updateButton) updateButton.addEventListener('click', () => autoUpdateGroup());
+
+      // Attach dropdown toggle
+      const dropdownButton = panel.querySelector('#panel-node-editor-parent-label-dropdown button');
+      if (dropdownButton) dropdownButton.addEventListener('click', () => this.panelNodeEditorParentToggleDropdown());
+
     } catch (error) {
       log.error(`showGroupEditor failed: ${error}`);
     }

--- a/src/topoViewer/webview-ui/tailwind.css
+++ b/src/topoViewer/webview-ui/tailwind.css
@@ -517,6 +517,22 @@
   .is-unselectable {
     user-select: none;
   }
+
+  /* Prevent text selection on body by default - only allow in specific areas */
+  body {
+    user-select: none;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+  }
+
+  /* Allow text selection in input fields, textareas, and editable content */
+  input, textarea, [contenteditable="true"], .selectable-text {
+    user-select: text;
+    -webkit-user-select: text;
+    -moz-user-select: text;
+    -ms-user-select: text;
+  }
   
   /* Field utilities */
   .field {

--- a/src/topoViewer/webview-ui/topologyWebviewController.ts
+++ b/src/topoViewer/webview-ui/topologyWebviewController.ts
@@ -408,6 +408,9 @@ class TopologyWebviewController {
         }
       }
     });
+
+    // Focus the container after initialization
+    document.getElementById('cy')?.focus();
   }
 
   /**

--- a/test/unit/topoViewer/managerCytoscapeBaseStyles.test.ts
+++ b/test/unit/topoViewer/managerCytoscapeBaseStyles.test.ts
@@ -1,9 +1,43 @@
 /* eslint-env mocha */
-/* global describe, it */
+/* global describe, it, before, beforeEach, after, global */
 import { expect } from 'chai';
 import { getCytoscapeStyles, extractNodeIcons } from '../../../src/topoViewer/webview-ui/managerCytoscapeBaseStyles';
 
 describe('managerCytoscapeBaseStyles', () => {
+  let originalWindow: any;
+  let originalDocument: any;
+
+  before(() => {
+    // Save original values
+    originalWindow = (global as any).window;
+    originalDocument = (global as any).document;
+  });
+
+  beforeEach(() => {
+    // Set up mocks before each test
+    (global as any).window = {
+      getComputedStyle: () => ({
+        getPropertyValue: (prop: string) => {
+          const values: Record<string, string> = {
+            '--vscode-focusBorder': '#007acc',
+            '--vscode-list-focusBackground': '#073655',
+          };
+          return values[prop] || '';
+        },
+      }),
+    };
+
+    (global as any).document = {
+      documentElement: {},
+    };
+  });
+
+  after(() => {
+    // Restore original values
+    (global as any).window = originalWindow;
+    (global as any).document = originalDocument;
+  });
+
   it('applies group styling based on theme', () => {
     const light = getCytoscapeStyles('light');
     const dark = getCytoscapeStyles('dark');


### PR DESCRIPTION
Have to admit I don't think the shortcut events in the topo-webview-controller is so nice implemented if you know better practice would like to learn.

Also should probably review the esc+enter modal implemention should i separate it as typescript code?(currently it is in the confirm-dialog.html😅)

See: [#issuecomment-3199596851](https://github.com/srl-labs/vscode-containerlab/issues/259#issuecomment-3199596851) for preview images

## Changes
1. `ctrl+a` selects all items
2. Item highlighting using vs-code focus color #245 
3. Selection Deletion with popup for multi delete #259 
4. Confirm bulk update 
5. Fixed group bulk link
6. #269 
7. double click -> opens edit modal
8. g-key -> new group
9. Shortcut-List-Modal
10. Enhanced Group Modal -> live color








