### PR TITLE
Dev easy launch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,11 @@ dist
 node_modules
 .vscode-test/
 topoViewerData
-.vscode/
+.vscode/*
+!.vscode/
+!.vscode/launch.json
+
 package.json
-.vscode/launch.json
 .DS_Store
 **/.DS_Store
 *.vsix

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+  "configurations": [
+    {
+      "name": "Run Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "runtimeExecutable": "${execPath}",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/dist/**/*.js"
+      ],
+      "preLaunchTask": "npm: package",
+      "cwd": "${workspaceFolder}"
+    }
+  ]
+}


### PR DESCRIPTION
You had launch.json in the gitignore so probably you don't want that?
If so forget this pull request again. 

I will keep it for me but this here allows to press f5 and vs-code executes npm run package and after that starts VS Code Development ( I always had to be in a file of the src-folder to be able to use that)