### PR TITLE
Fix unwanted reload

### DIFF
--- a/src/topoViewer/providers/topoViewerEditorWebUiFacade.ts
+++ b/src/topoViewer/providers/topoViewerEditorWebUiFacade.ts
@@ -635,6 +635,24 @@ topology:
     return imageMapping;
   }
 
+  private async updateCachedYamlFromCurrentDoc(): Promise<void> {
+    if (!this.currentLabName) {
+      return;
+    }
+
+    const doc = this.adaptor.currentClabDoc;
+    if (!doc) {
+      return;
+    }
+
+    try {
+      const yaml = doc.toString();
+      await this.context.workspaceState.update(`cachedYaml_${this.currentLabName}`, yaml);
+    } catch (err) {
+      log.warn(`Failed to update cached YAML after save: ${err}`);
+    }
+  }
+
   /**
    * Creates a new webview panel or reveals the current one.
    * @param context The extension context.
@@ -1124,6 +1142,7 @@ topology:
           this.isInternalUpdate = v;
         }
       });
+      await this.updateCachedYamlFromCurrentDoc();
       const result = 'Saved topology with preserved comments!';
       log.info(result);
       return { result, error: null };
@@ -1149,6 +1168,7 @@ topology:
           this.isInternalUpdate = v;
         }
       });
+      await this.updateCachedYamlFromCurrentDoc();
       return { result: null, error: null };
     } catch (err) {
       const result = 'Error executing endpoint "topo-editor-viewport-save-suppress-notification".';


### PR DESCRIPTION
In TopoViewer, when we select a new default custom node and than adding it to the canvas, is trigger a reload of TopoViewer and locks the lab. There should be no reload of the TopoViewer in this case. This is fixed by this PR