### PR TITLE
feat: refresh docker images when node editor panel is opened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Change Log
+## [0.19.3] - 2025-09-29
+- refresh docker images when node editor panel is opened
+- fixes
 
 ## [0.19.0] - 2025-09-29
 - TopoViewer/editor:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-containerlab",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-containerlab",
-      "version": "0.19.2",
+      "version": "0.19.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "@fortawesome/fontawesome-free": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "icon": "resources/containerlab.png",
   "description": "Manages containerlab topologies in VS Code",
   "author": "SRL Labs",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "homepage": "https://containerlab.dev/manual/vsc-extension/",
   "engines": {
     "vscode": "^1.99.0"

--- a/src/topoViewer/providers/topoViewerEditorWebUiFacade.ts
+++ b/src/topoViewer/providers/topoViewerEditorWebUiFacade.ts
@@ -88,6 +88,7 @@ export class TopoViewerEditor {
     'topo-editor-save-custom-node': this.handleSaveCustomNodeEndpoint.bind(this),
     'topo-editor-delete-custom-node': this.handleDeleteCustomNodeEndpoint.bind(this),
     'topo-editor-set-default-custom-node': this.handleSetDefaultCustomNodeEndpoint.bind(this),
+    'refresh-docker-images': this.handleRefreshDockerImagesEndpoint.bind(this),
     showError: this.handleShowErrorEndpoint.bind(this),
     'topo-toggle-split-view': this.handleToggleSplitViewEndpoint.bind(this),
     copyElements: this.handleCopyElementsEndpoint.bind(this),
@@ -1683,6 +1684,23 @@ topology:
     const clipboard = this.context.globalState.get('topoClipboard') || [];
     panel.webview.postMessage({ type: 'copiedElements', data: clipboard });
     return { result: 'Clipboard sent', error: null };
+  }
+
+  private async handleRefreshDockerImagesEndpoint(
+    _payload: string | undefined,
+    _payloadObj: any,
+    _panel: vscode.WebviewPanel
+  ): Promise<{ result: unknown; error: string | null }> {
+    try {
+      await refreshDockerImages(this.context);
+      const dockerImages = (this.context.globalState.get<string[]>('dockerImages') || []) as string[];
+      log.info(`Docker images refreshed, found ${dockerImages.length} images`);
+      return { result: { success: true, dockerImages }, error: null };
+    } catch (err) {
+      const error = `Error refreshing docker images: ${err}`;
+      log.error(`Error refreshing docker images: ${JSON.stringify(err, null, 2)}`);
+      return { result: null, error };
+    }
   }
 
   /* eslint-enable no-unused-vars */


### PR DESCRIPTION
Currently the docker images are only fetched once.. if I pull something it will not show in the node editor panel img dropdown unless I reload the window.

This PR fixes that.. I just need to close the editor panel, and re open it, and the image will apper

