### PR TITLE
Fix mgmt not getting read from yaml

### DIFF
--- a/src/reactTopoViewer/webview/hooks/panels/useLabSettings.ts
+++ b/src/reactTopoViewer/webview/hooks/panels/useLabSettings.ts
@@ -87,7 +87,9 @@ function readLabSettingsFromDocument(): LabSettings | undefined {
     // Read name, prefix, and mgmt from root level (per clab schema)
     const name = doc.get("name") as string | undefined;
     const prefix = doc.get("prefix") as string | undefined;
-    const mgmt = doc.get("mgmt") as Record<string, unknown> | undefined;
+    const mgmt = (doc.get("mgmt") as YAML.YAMLMap | undefined)?.toJSON() as
+      | Record<string, unknown>
+      | undefined;
 
     const settings: LabSettings = {};
     if (name) settings.name = name;


### PR DESCRIPTION
Management was not getting read from yaml due to a type error. YAML is returning a yaml map instead of an object.