### PR TITLE
feat: add timer to deploy/destroy lifecycle modal

### DIFF
--- a/src/reactTopoViewer/webview/utils/lifecycleTimer.ts
+++ b/src/reactTopoViewer/webview/utils/lifecycleTimer.ts
@@ -1,0 +1,16 @@
+export function calculateElapsedSeconds(startedAtMs: number, nowMs: number = Date.now()): number {
+  return Math.max(0, Math.floor((nowMs - startedAtMs) / 1000));
+}
+
+export function formatElapsedSeconds(elapsedSeconds: number): string {
+  const totalSeconds = Math.max(0, Math.floor(elapsedSeconds));
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+  }
+
+  return `${minutes}:${String(seconds).padStart(2, "0")}`;
+}

--- a/test/unit/reactTopoViewer/lifecycleTimer.test.ts
+++ b/test/unit/reactTopoViewer/lifecycleTimer.test.ts
@@ -1,0 +1,36 @@
+/* global describe, it */
+import { expect } from "chai";
+
+import {
+  calculateElapsedSeconds,
+  formatElapsedSeconds
+} from "../../../src/reactTopoViewer/webview/utils/lifecycleTimer";
+
+describe("calculateElapsedSeconds", () => {
+  it("returns whole elapsed seconds", () => {
+    expect(calculateElapsedSeconds(1000, 5000)).to.equal(4);
+    expect(calculateElapsedSeconds(1000, 5999)).to.equal(4);
+  });
+
+  it("clamps negative durations to zero", () => {
+    expect(calculateElapsedSeconds(5000, 1000)).to.equal(0);
+  });
+});
+
+describe("formatElapsedSeconds", () => {
+  it("formats minutes and seconds under one hour", () => {
+    expect(formatElapsedSeconds(0)).to.equal("0:00");
+    expect(formatElapsedSeconds(5)).to.equal("0:05");
+    expect(formatElapsedSeconds(65)).to.equal("1:05");
+  });
+
+  it("formats hours with zero-padded minutes and seconds", () => {
+    expect(formatElapsedSeconds(3600)).to.equal("1:00:00");
+    expect(formatElapsedSeconds(3661)).to.equal("1:01:01");
+  });
+
+  it("clamps invalid values to zero", () => {
+    expect(formatElapsedSeconds(-1)).to.equal("0:00");
+    expect(formatElapsedSeconds(2.9)).to.equal("0:02");
+  });
+});


### PR DESCRIPTION
## Summary
- add an elapsed timer to the lifecycle modal while deploy/destroy is running
- freeze and relabel the timer as duration once the command completes/fails
- add shared timer formatting utilities with unit tests

## Testing
- npm run lint
- npm run test:compile
- npx mocha --extension js out/test/test/unit/reactTopoViewer/lifecycleTimer.test.js

Closes #541