### PR TITLE
fix(topoviewer): align Monaco webview behavior with dev mode

### DIFF
--- a/src/reactTopoViewer/extension/panel/PanelManager.ts
+++ b/src/reactTopoViewer/extension/panel/PanelManager.ts
@@ -100,11 +100,6 @@ export function generateWebviewHtml(data: WebviewHtmlData): string {
     vscode.Uri.joinPath(extensionUri, "dist", "monaco-json-worker.js")
   );
 
-  // Get schema URI for kind/type dropdowns
-  const schemaUri = webview
-    .asWebviewUri(vscode.Uri.joinPath(extensionUri, "schema", "clab.schema.json"))
-    .toString();
-
   // CSP nonce for security
   const nonce = generateNonce();
 
@@ -116,7 +111,7 @@ export function generateWebviewHtml(data: WebviewHtmlData): string {
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource} 'unsafe-inline'; script-src 'nonce-${nonce}'; img-src ${webview.cspSource} https: data:; font-src ${webview.cspSource}; connect-src ${webview.cspSource} https://basemaps.cartocdn.com https://*.basemaps.cartocdn.com https://tile.openstreetmap.org; worker-src ${webview.cspSource} blob:;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource} 'unsafe-inline'; script-src 'nonce-${nonce}' 'unsafe-eval'; img-src ${webview.cspSource} https: data:; font-src ${webview.cspSource}; connect-src ${webview.cspSource} https://basemaps.cartocdn.com https://*.basemaps.cartocdn.com https://tile.openstreetmap.org; worker-src ${webview.cspSource} blob:;">
   <link href="${styleUri}" rel="stylesheet">
   <title>TopoViewer (React)</title>
 </head>
@@ -126,7 +121,6 @@ export function generateWebviewHtml(data: WebviewHtmlData): string {
     // Acquire VS Code API for webview communication
     window.vscode = acquireVsCodeApi();
     window.__INITIAL_DATA__ = ${initialDataJson};
-    window.schemaUrl = "${schemaUri}";
     window.maplibreWorkerUrl = "${maplibreWorkerUri.toString()}";
     window.maplibreWorkerSourceBase64 = "${maplibreWorkerSourceBase64}";
     window.monacoEditorWorkerUrl = "${monacoEditorWorkerUri.toString()}";

--- a/src/reactTopoViewer/webview/components/monaco/MonacoCodeEditor.tsx
+++ b/src/reactTopoViewer/webview/components/monaco/MonacoCodeEditor.tsx
@@ -724,8 +724,7 @@ export const MonacoCodeEditor: React.FC<MonacoCodeEditorProps> = ({
       model: modelRef.current,
       readOnly,
       automaticLayout: true,
-      // Use the native context menu so standard right-click paste works in webviews.
-      contextmenu: false,
+      contextmenu: true,
       minimap: { enabled: false },
       scrollBeyondLastLine: false,
       fontFamily: getEditorFontFamily(),
@@ -802,11 +801,5 @@ export const MonacoCodeEditor: React.FC<MonacoCodeEditorProps> = ({
     lastExternalAppliedRef.current = next;
   }, [value]);
 
-  return (
-    <div
-      ref={containerRef}
-      style={{ width: "100%", height: "100%" }}
-      onContextMenuCapture={(event) => event.stopPropagation()}
-    />
-  );
+  return <div ref={containerRef} style={{ width: "100%", height: "100%" }} />;
 };

--- a/src/reactTopoViewer/webview/components/panels/lab-drawer/PaletteSection.tsx
+++ b/src/reactTopoViewer/webview/components/panels/lab-drawer/PaletteSection.tsx
@@ -463,7 +463,7 @@ export const PaletteSection: React.FC<PaletteSectionProps> = ({
   const [annotationsDraft, setAnnotationsDraft] = useState<string>(annotationsContent);
   const [yamlDirty, setYamlDirty] = useState(false);
   const [annotationsDirty, setAnnotationsDirty] = useState(false);
-  const isSourceReadOnly = isLocked || isViewMode;
+  const isSourceReadOnly = isLocked;
 
   // Sync drafts with host unless user has local edits
   useEffect(() => {


### PR DESCRIPTION
## Summary
- allow Monaco native context menu in webview so right-click copy/paste works
- stop wrapper-level contextmenu capture from swallowing Monaco interactions
- make source editor read-only depend on lock state only (not view mode)
- improve keyboard shortcut focus detection so app-level shortcuts do not hijack Monaco/input events
- update TopoViewer webview CSP to allow Ajv schema validation runtime in VS Code webview

## Validation
- npm run -s typecheck
- npm run -s build