### PR TITLE
fix(topoviewer): show traffic-rate annotations immediately and prevent editor/render lag

### DIFF
--- a/src/reactTopoViewer/webview/components/panels/context-panel/views/TrafficRateEditorView.tsx
+++ b/src/reactTopoViewer/webview/components/panels/context-panel/views/TrafficRateEditorView.tsx
@@ -343,23 +343,32 @@ function useTrafficRateCommitHandlers(params: {
   initialSerializedRef: { current: string | null };
   hasPreviewRef: { current: boolean };
 }) {
+  const {
+    onSave,
+    discardChanges,
+    previewRef,
+    initialAnnotationRef,
+    initialSerializedRef,
+    hasPreviewRef
+  } = params;
+
   const saveWithCommit = useCallback(
     (next: TrafficRateAnnotation) => {
-      params.hasPreviewRef.current = false;
-      params.initialAnnotationRef.current = { ...next };
-      params.initialSerializedRef.current = JSON.stringify(next);
-      params.onSave(next);
+      hasPreviewRef.current = false;
+      initialAnnotationRef.current = { ...next };
+      initialSerializedRef.current = JSON.stringify(next);
+      onSave(next);
     },
-    [params]
+    [hasPreviewRef, initialAnnotationRef, initialSerializedRef, onSave]
   );
 
   const discardWithRevert = useCallback(() => {
-    params.discardChanges();
-    if (params.initialAnnotationRef.current) {
-      params.previewRef.current?.(params.initialAnnotationRef.current);
+    discardChanges();
+    if (initialAnnotationRef.current) {
+      previewRef.current?.(initialAnnotationRef.current);
     }
-    params.hasPreviewRef.current = false;
-  }, [params]);
+    hasPreviewRef.current = false;
+  }, [discardChanges, initialAnnotationRef, previewRef, hasPreviewRef]);
 
   return { saveWithCommit, discardWithRevert };
 }

--- a/src/reactTopoViewer/webview/hooks/canvas/useTrafficRateAnnotations.ts
+++ b/src/reactTopoViewer/webview/hooks/canvas/useTrafficRateAnnotations.ts
@@ -85,9 +85,19 @@ export function useTrafficRateAnnotations(
         groupId: parentGroup?.id
       };
 
+      derived.addTrafficRateAnnotation(annotation);
+      persist();
       uiActions.setEditingTrafficRateAnnotation(annotation);
     },
-    [canEditAnnotations, onLockedAction, derived.groups, derived.trafficRateAnnotations, uiActions]
+    [
+      canEditAnnotations,
+      onLockedAction,
+      derived.addTrafficRateAnnotation,
+      derived.groups,
+      derived.trafficRateAnnotations,
+      uiActions,
+      persist
+    ]
   );
 
   const editTrafficRateAnnotation = useCallback(


### PR DESCRIPTION
## Summary
- add traffic-rate annotations to graph immediately when added to the canvas so they render right away with defaults
- fix the traffic-rate editor callback dependency churn that caused "Maximum update depth exceeded" loops
- throttle color picker drag updates (with final blur flush) to reduce lag during style changes
- resolve strict boolean lint warning in ColorField

## Validation
- npm run typecheck
- npm run lint