### PR TITLE
fix(ssh): use distributed srsim basename host instead of -a fallback

### DIFF
--- a/src/commands/ssh.ts
+++ b/src/commands/ssh.ts
@@ -9,23 +9,58 @@ import { sshUserMapping } from "../globals";
 
 import { execCommandInTerminal } from "./command";
 
+function resolveDistributedSrosSshTarget(node: ClabContainerTreeNode): string | undefined {
+  if (node.kind !== "nokia_srsim") {
+    return undefined;
+  }
+
+  const rootNodeName = node.rootNodeName?.trim();
+  if (rootNodeName === undefined || rootNodeName.length === 0 || node.name.length === 0) {
+    return undefined;
+  }
+
+  const fullName = node.name.trim();
+  const shortName = node.name_short.trim();
+  if (shortName.length > 0 && shortName.length < fullName.length && fullName.endsWith(shortName)) {
+    return `${fullName.slice(0, fullName.length - shortName.length)}${rootNodeName}`;
+  }
+
+  const suffixSeparator = fullName.lastIndexOf("-");
+  if (suffixSeparator > 0) {
+    return fullName.slice(0, suffixSeparator);
+  }
+
+  return undefined;
+}
+
+function resolveSshTarget(node: ClabContainerTreeNode): string | undefined {
+  const distributedSrosTarget = resolveDistributedSrosSshTarget(node);
+  if (distributedSrosTarget !== undefined && distributedSrosTarget.length > 0) {
+    return distributedSrosTarget;
+  }
+  if (node.name.length > 0) {
+    return node.name;
+  }
+  if (node.v6Address !== undefined && node.v6Address.length > 0) {
+    return node.v6Address;
+  }
+  if (node.v4Address !== undefined && node.v4Address.length > 0) {
+    return node.v4Address;
+  }
+  if (node.cID.length > 0) {
+    return node.cID;
+  }
+  return undefined;
+}
+
 export function sshToNode(node: ClabContainerTreeNode | undefined): void {
   if (!node) {
     vscode.window.showErrorMessage("No container node selected.");
     return;
   }
 
-  let sshTarget: string | undefined;
-
-  if (node.name) {
-    sshTarget = node.name;
-  } else if (node.v6Address !== undefined && node.v6Address.length > 0) {
-    sshTarget = node.v6Address;
-  } else if (node.v4Address !== undefined && node.v4Address.length > 0) {
-    sshTarget = node.v4Address;
-  } else if (node.cID) {
-    sshTarget = node.cID;
-  } else {
+  const sshTarget = resolveSshTarget(node);
+  if (sshTarget === undefined) {
     vscode.window.showErrorMessage("No target to connect to container");
     return;
   }
@@ -38,14 +73,7 @@ export function sshToNode(node: ClabContainerTreeNode | undefined): void {
   // Use user setting first, then default mapping, then fallback to "admin"
   const sshUser = userSshMapping[node.kind] ?? defaultMapping[node.kind] ?? "admin";
 
-  let container = "Container";
-  if (node.name.length > 0) {
-    container = node.name;
-  } else if (node.cID.length > 0) {
-    container = node.cID;
-  }
-
-  execCommandInTerminal(`ssh ${sshUser}@${sshTarget}`, `SSH - ${container}`, true);
+  execCommandInTerminal(`ssh ${sshUser}@${sshTarget}`, `SSH - ${sshTarget}`, true);
 }
 
 export function sshToLab(node: ClabLabTreeNode | undefined): void {

--- a/test/unit/commands/ssh.test.ts
+++ b/test/unit/commands/ssh.test.ts
@@ -1,0 +1,98 @@
+/* global describe, it, after, beforeEach, afterEach */
+/**
+ * Tests for the `sshToNode` command.
+ *
+ * The suite verifies that distributed Nokia SR SIM nodes SSH to the
+ * base node hostname (without slot suffixes) while other node kinds
+ * retain existing behavior.
+ */
+import Module from "module";
+import path from "path";
+
+import { expect } from "chai";
+import sinon from "sinon";
+
+const originalResolve = (Module as any)._resolveFilename;
+(Module as any)._resolveFilename = function (
+  request: string,
+  parent: any,
+  isMain: boolean,
+  options: any
+) {
+  if (request === "vscode") {
+    return path.join(__dirname, "..", "..", "helpers", "vscode-stub.js");
+  }
+  return originalResolve.call(this, request, parent, isMain, options);
+};
+
+const commandPath = require.resolve("../../../src/commands/command");
+(require.cache as any)[commandPath] = {
+  exports: require("../../helpers/command-stub.js")
+} as any;
+
+import { sshToNode } from "../../../src/commands/ssh";
+
+const vscodeStub = require("../../helpers/vscode-stub");
+const commandStub = require("../../helpers/command-stub");
+
+describe("sshToNode command", () => {
+  after(() => {
+    (Module as any)._resolveFilename = originalResolve;
+  });
+
+  beforeEach(() => {
+    commandStub.calls.length = 0;
+    vscodeStub.window.lastErrorMessage = "";
+    vscodeStub.workspace.getConfiguration = () => ({
+      get: <T>(_: string, defaultValue?: T): T | undefined => defaultValue
+    });
+    sinon.spy(vscodeStub.window, "showErrorMessage");
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("uses base hostname for distributed nokia_srsim container nodes", () => {
+    const node = {
+      name: "clab-SRv6_lab-R1-a",
+      name_short: "R1-a",
+      rootNodeName: "R1",
+      kind: "nokia_srsim",
+      cID: "ctr-r1-a",
+      v4Address: "",
+      v6Address: ""
+    } as any;
+
+    sshToNode(node);
+
+    expect(commandStub.calls).to.have.lengthOf(1);
+    expect(commandStub.calls[0].command).to.equal("ssh admin@clab-SRv6_lab-R1");
+    expect(commandStub.calls[0].terminalName).to.equal("SSH - clab-SRv6_lab-R1");
+  });
+
+  it("keeps direct container hostname for non-distributed nodes", () => {
+    const node = {
+      name: "clab-testlab-r2",
+      name_short: "r2",
+      kind: "nokia_srlinux",
+      cID: "ctr-r2",
+      v4Address: "",
+      v6Address: ""
+    } as any;
+
+    sshToNode(node);
+
+    expect(commandStub.calls).to.have.lengthOf(1);
+    expect(commandStub.calls[0].command).to.equal("ssh admin@clab-testlab-r2");
+    expect(commandStub.calls[0].terminalName).to.equal("SSH - clab-testlab-r2");
+  });
+
+  it("shows an error when no node is provided", () => {
+    sshToNode(undefined);
+
+    expect(commandStub.calls).to.have.lengthOf(0);
+    const msgSpy = vscodeStub.window.showErrorMessage as sinon.SinonSpy;
+    expect(msgSpy.calledOnceWith("No container node selected.")).to.be.true;
+  });
+});


### PR DESCRIPTION
## Summary
  - remove legacy -a SSH target behavior for distributed nokia_srsim
  - use base containerlab hostname for SSH target resolution
  - add unit tests for distributed and non-distributed SSH target behavior