### PR TITLE
fix(running-labs): parse long docker uptime units from events

### DIFF
--- a/src/services/containerlabEvents.ts
+++ b/src/services/containerlabEvents.ts
@@ -925,22 +925,28 @@ function toDurationSeconds(unit: string): number {
   if (normalized.endsWith("s")) {
     normalized = normalized.slice(0, -1);
   }
-  if (normalized === "mins") {
-    normalized = "min";
-  }
-  if (normalized === "hrs") {
-    normalized = "hour";
-  }
   switch (normalized) {
     case "second":
+    case "sec":
       return 1;
     case "minute":
     case "min":
       return 60;
     case "hour":
+    case "hr":
       return 3600;
     case "day":
       return 86400;
+    case "week":
+    case "wk":
+      return 7 * 86400;
+    case "month":
+    case "mo":
+      // Docker status uses humanized durations; treat month/year as coarse units.
+      return 30 * 86400;
+    case "year":
+    case "yr":
+      return 365 * 86400;
     default:
       return 0;
   }
@@ -1369,6 +1375,13 @@ export function resetForTests(): void {
   interfaceVersions.clear();
   nodeSnapshots.clear();
   scheduleDataChanged();
+}
+
+export function estimateStartedAtFromStatusForTests(
+  status: string | undefined,
+  eventTimestamp?: number
+): number | undefined {
+  return estimateStartedAtFromStatus(status, eventTimestamp);
 }
 
 export function onDataChanged(listener: DataListener): () => void {

--- a/test/unit/services/containerlabEvents.test.ts
+++ b/test/unit/services/containerlabEvents.test.ts
@@ -1,0 +1,40 @@
+/* global describe, it, after */
+import Module from "module";
+import path from "path";
+
+import { expect } from "chai";
+
+const originalResolve = (Module as any)._resolveFilename;
+(Module as any)._resolveFilename = function (
+  request: string,
+  parent: any,
+  isMain: boolean,
+  options: any
+) {
+  if (request === "vscode") {
+    return path.join(__dirname, "..", "..", "helpers", "vscode-stub.js");
+  }
+  return originalResolve.call(this, request, parent, isMain, options);
+};
+
+import { estimateStartedAtFromStatusForTests } from "../../../src/services/containerlabEvents";
+
+describe("containerlabEvents uptime parsing", () => {
+  after(() => {
+    (Module as any)._resolveFilename = originalResolve;
+  });
+
+  it("parses week-based uptime from docker status", () => {
+    const eventTimestamp = Date.parse("2026-02-25T12:00:00.000Z");
+    const parsed = estimateStartedAtFromStatusForTests("Up 2 weeks", eventTimestamp);
+
+    expect(parsed).to.equal(eventTimestamp - 14 * 24 * 60 * 60 * 1000);
+  });
+
+  it("parses week-based uptime with health suffix", () => {
+    const eventTimestamp = Date.parse("2026-02-25T12:00:00.000Z");
+    const parsed = estimateStartedAtFromStatusForTests("Up 2 weeks (healthy)", eventTimestamp);
+
+    expect(parsed).to.equal(eventTimestamp - 14 * 24 * 60 * 60 * 1000);
+  });
+});


### PR DESCRIPTION
## Summary
- parse long Docker uptime units in events status parsing (`week`, `month`, `year`, plus short aliases)
- prevent uptime from resetting to VS Code-open time when status is like `Up 2 weeks`
- add regression tests for week-based statuses with and without health suffix

## Validation
- npm run compile
- npm run test:compile
- npx mocha --extension js "out/test/test/unit/services/containerlabEvents.test.js"

Fixes #553