### PR TITLE
Allow appearance changes for running labs

### DIFF
--- a/src/reactTopoViewer/webview/components/panels/lab-drawer/LabSettingsSection.tsx
+++ b/src/reactTopoViewer/webview/components/panels/lab-drawer/LabSettingsSection.tsx
@@ -39,7 +39,8 @@ export const LabSettingsSection: React.FC<LabSettingsSectionProps> = ({
   onResetGridColors
 }) => {
   const [activeTab, setActiveTab] = useState("basic");
-  const isReadOnly = mode === "view" || isLocked;
+  const areTopologySettingsReadOnly = mode === "view" || isLocked;
+  const isAppearanceReadOnly = isLocked;
 
   const state = useLabSettingsState(labSettings);
   const linkLabelMode = useTopoViewerStore((store) => store.linkLabelMode);
@@ -52,7 +53,9 @@ export const LabSettingsSection: React.FC<LabSettingsSectionProps> = ({
   );
 
   const handleSave = async () => {
-    await state.handleSave();
+    if (!areTopologySettingsReadOnly) {
+      await state.handleSave();
+    }
     const style = linkLabelMode === "telemetry-style" ? "telemetry-style" : "default";
     const nextLastNonTelemetryLinkLabelMode =
       linkLabelMode === "telemetry-style" ? lastNonTelemetryLinkLabelMode : linkLabelMode;
@@ -95,7 +98,7 @@ export const LabSettingsSection: React.FC<LabSettingsSectionProps> = ({
             labName={state.basic.labName}
             prefixType={state.basic.prefixType}
             customPrefix={state.basic.customPrefix}
-            isViewMode={isReadOnly}
+            isViewMode={areTopologySettingsReadOnly}
             onLabNameChange={state.setBasic.setLabName}
             onPrefixTypeChange={state.setBasic.setPrefixType}
             onCustomPrefixChange={state.setBasic.setCustomPrefix}
@@ -117,7 +120,7 @@ export const LabSettingsSection: React.FC<LabSettingsSectionProps> = ({
           bridge={state.mgmt.bridge}
           externalAccess={state.mgmt.externalAccess}
           driverOptions={state.mgmt.driverOptions}
-          isViewMode={isReadOnly}
+          isViewMode={areTopologySettingsReadOnly}
           onNetworkNameChange={state.setMgmt.setNetworkName}
           onIpv4TypeChange={state.setMgmt.setIpv4Type}
           onIpv4SubnetChange={state.setMgmt.setIpv4Subnet}
@@ -146,7 +149,7 @@ export const LabSettingsSection: React.FC<LabSettingsSectionProps> = ({
             gridBgColor={gridBgColor}
             onGridBgColorChange={onGridBgColorChange}
             onResetGridColors={onResetGridColors}
-            isReadOnly={isReadOnly}
+            isReadOnly={isAppearanceReadOnly}
           />
         </Box>
       )}

--- a/src/reactTopoViewer/webview/components/panels/lab-settings/LabSettingsModal.tsx
+++ b/src/reactTopoViewer/webview/components/panels/lab-settings/LabSettingsModal.tsx
@@ -38,7 +38,7 @@ export const LabSettingsModal: React.FC<LabSettingsModalProps> = ({
   onResetGridColors
 }) => {
   const saveRef = useRef<(() => Promise<void>) | null>(null);
-  const isReadOnly = mode === "view" || isLocked;
+  const canSave = !isLocked;
   const handleSaveClick = useCallback(() => {
     const save = saveRef.current;
     if (!save) {
@@ -84,7 +84,7 @@ export const LabSettingsModal: React.FC<LabSettingsModalProps> = ({
           onResetGridColors={onResetGridColors}
         />
       </DialogContent>
-      {!isReadOnly && (
+      {canSave && (
         <DialogActions>
           <Button size="small" onClick={handleSaveClick} data-testid="lab-settings-save-btn">
             Apply

--- a/test/e2e/specs/lab-settings-panel.spec.ts
+++ b/test/e2e/specs/lab-settings-panel.spec.ts
@@ -301,16 +301,46 @@ test.describe("Lab Settings Modal", () => {
     ).toBeDisabled();
   });
 
-  test("Save button is hidden in view mode", async ({ page, topoViewerPage }) => {
+  test("view mode keeps topology settings read-only and can still save appearance", async ({
+    page,
+    topoViewerPage
+  }) => {
     await topoViewerPage.setViewMode();
 
     const modal = await openModal(page);
 
     const saveBtn = page.locator(SEL_LAB_SETTINGS_SAVE_BTN);
-    await expect(saveBtn).not.toBeVisible();
+    await expect(saveBtn).toBeVisible();
 
     await expect(modal.getByRole("textbox", { name: "Lab Name" })).toBeDisabled();
     await expectMuiSelectDisabled(modal, LABEL_CONTAINER_NAME_PREFIX);
+
+    await modal.locator(SEL_LAB_SETTINGS_TAB_APPEARANCE).click();
+    await page.waitForTimeout(150);
+
+    const styleSelect = modal
+      .locator('[data-testid="lab-settings-telemetry-style"] [role="combobox"]')
+      .first();
+    await styleSelect.click();
+    await chooseOption(page, /^Telemetry Style$/);
+
+    await modal.getByLabel("Node size").fill("72");
+
+    await saveBtn.click();
+    await expect(modal).not.toBeVisible({ timeout: 3000 });
+
+    await expect
+      .poll(
+        async () => {
+          const annotations = await topoViewerPage.getAnnotationsFromFile(SIMPLE_FILE);
+          return annotations.viewerSettings ?? {};
+        },
+        { timeout: 5000 }
+      )
+      .toMatchObject({
+        style: "telemetry-style",
+        telemetryNodeSizePx: 72
+      });
   });
 
   test("can change prefix type to custom and enter custom prefix", async ({ page }) => {


### PR DESCRIPTION
## Summary
- allow lab appearance changes to be applied in unlocked view mode for running labs
- keep Basic and Management settings read-only in view mode
- update the lab settings E2E coverage for view-mode appearance saves

## Validation
- npm run package