### PR TITLE
fix: correct cisco_xrv9k SSH user typo and add XR kinds to default map

### DIFF
--- a/resources/ssh_users.json
+++ b/resources/ssh_users.json
@@ -2,7 +2,9 @@
   "nokia_srlinux": "admin",
   "nokia_sros": "admin",
   "cisco_xrd": "clab",
-  "cisco_xr9vk": "clab",
+  "cisco_xrv9k": "clab",
+  "cisco_xrd_vrouter": "clab",
+  "cisco_xrv": "clab",
   "arista_ceos": "admin",
   "juniper_crpd": "root"
 }


### PR DESCRIPTION
`resources/ssh_users.json` mapped **`cisco_xr9vk`** — a typo (the `9` and `v` are transposed) for **`cisco_xrv9k`**. Because that key never matches a real kind, `cisco_xrv9k` nodes fall through to the `?? "admin"` fallback in `src/commands/ssh.ts`, so **Access → SSH** connects as `admin@` instead of `clab@`.

This PR:

- fixes the typo `cisco_xr9vk` → `cisco_xrv9k`;
- adds **`cisco_xrd_vrouter`** (the XRd vRouter kind) and **`cisco_xrv`**.

All four Cisco XR kinds use the `clab` default user. No change for kinds already mapped, and users can still override via the `containerlab.node.sshUserMapping` setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
