### PR TITLE
Add containerlab apply command and always-editable TopoViewer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "vscode-containerlab",
-  "version": "0.25.4",
+  "version": "0.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-containerlab",
-      "version": "0.25.4",
+      "version": "0.26.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@srl-labs/clab-ui": "0.1.0",
+        "@srl-labs/clab-ui": "0.2.0",
         "@types/chai": "^5.2.3",
         "@types/dockerode": "^4.0.1",
         "@types/mocha": "^10.0.10",
@@ -2502,7 +2502,7 @@
       }
     },
     "node_modules/@srl-labs/clab-ui": {
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "icon": "resources/containerlab.png",
   "description": "Manages containerlab topologies in VS Code",
   "author": "SRL Labs",
-  "version": "0.25.4",
+  "version": "0.26.0",
   "homepage": "https://containerlab.dev/manual/vsc-extension/",
   "engines": {
     "vscode": "^1.105.1",
@@ -1058,7 +1058,7 @@
     "uuid": "14.0.0"
   },
   "devDependencies": {
-    "@srl-labs/clab-ui": "0.1.0",
+    "@srl-labs/clab-ui": "0.2.0",
     "@types/chai": "^5.2.3",
     "@types/dockerode": "^4.0.1",
     "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -128,6 +128,12 @@
         "category": "Containerlab"
       },
       {
+        "command": "containerlab.lab.apply",
+        "title": "Apply topology",
+        "icon": "$(play)",
+        "category": "Containerlab"
+      },
+      {
         "command": "containerlab.lab.destroy",
         "title": "Destroy",
         "icon": "$(trash)",
@@ -485,6 +491,11 @@
       "editor/title/run": [
         {
           "when": "resourceFilename =~ /\\.clab\\.(yml|yaml)$/",
+          "command": "containerlab.lab.apply",
+          "group": "navigation@0"
+        },
+        {
+          "when": "resourceFilename =~ /\\.clab\\.(yml|yaml)$/",
           "command": "containerlab.lab.deploy",
           "group": "navigation@1"
         },
@@ -530,6 +541,11 @@
         }
       ],
       "editor/title/context": [
+        {
+          "when": "resourceFilename =~ /\\.clab\\.(yml|yaml)$/",
+          "command": "containerlab.lab.apply",
+          "group": "clabLabActions@0"
+        },
         {
           "when": "resourceFilename =~ /\\.clab\\.(yml|yaml)$/",
           "command": "containerlab.lab.deploy",
@@ -587,6 +603,11 @@
         }
       ],
       "explorer/context": [
+        {
+          "when": "resourceFilename =~ /\\.clab\\.(yml|yaml)$/",
+          "command": "containerlab.lab.apply",
+          "group": "clabLabActions@0"
+        },
         {
           "when": "resourceFilename =~ /\\.clab\\.(yml|yaml)$/",
           "command": "containerlab.lab.deploy",
@@ -661,6 +682,10 @@
           "when": "resourceFilename =~ /\\.clab\\.(yml|yaml)$/"
         },
         {
+          "command": "containerlab.lab.apply",
+          "when": "resourceFilename =~ /\\.clab\\.(yml|yaml)$/"
+        },
+        {
           "command": "containerlab.lab.destroy",
           "when": "resourceFilename =~ /\\.clab\\.(yml|yaml)$/"
         },
@@ -726,6 +751,11 @@
         "key": "ctrl+alt+r",
         "mac": "cmd+alt+r",
         "command": "containerlab.lab.redeploy"
+      },
+      {
+        "key": "ctrl+alt+a",
+        "mac": "cmd+alt+a",
+        "command": "containerlab.lab.apply"
       },
       {
         "key": "ctrl+alt+k",

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -1,0 +1,7 @@
+import type { ClabLabTreeNode } from "../treeView/common";
+
+import { runClabAction } from "./runClabAction";
+
+export async function apply(node?: ClabLabTreeNode) {
+  await runClabAction("apply", node);
+}

--- a/src/commands/graph.ts
+++ b/src/commands/graph.ts
@@ -7,7 +7,6 @@ import type { ClabLabTreeNode } from "../treeView/common";
 import type { ReactTopoViewer } from "../reactTopoViewer";
 import { ReactTopoViewerProvider } from "../reactTopoViewer";
 import { getSelectedLabNode } from "../utils/utils";
-import * as ins from "../treeView/inspector";
 import { MSG_LAB_LIFECYCLE_LOG, MSG_LAB_LIFECYCLE_STATUS } from "@srl-labs/clab-ui/session";
 
 import { ClabCommand } from "./clabCommand";
@@ -83,7 +82,14 @@ export async function graphDrawIOInteractive(node?: ClabLabTreeNode) {
 
 let currentTopoViewer: ReactTopoViewer | undefined;
 
-export type LifecycleCommandType = "deploy" | "destroy" | "redeploy" | "start" | "stop" | "restart";
+export type LifecycleCommandType =
+  | "deploy"
+  | "destroy"
+  | "redeploy"
+  | "apply"
+  | "start"
+  | "stop"
+  | "restart";
 type LifecycleCommandStream = "stdout" | "stderr";
 type TopoViewerLifecycleHandlers = {
   onSuccess: () => Promise<void>;
@@ -91,55 +97,15 @@ type TopoViewerLifecycleHandlers = {
   onOutputLine: (line: string, stream: LifecycleCommandStream) => void;
 };
 
-/**
- * Check if a lab is running by looking up its path in the inspector data.
- */
-function isLabRunning(labPath: string): boolean {
-  const inspectData = ins.rawInspectData;
-  if (!inspectData) {
-    return false;
-  }
-
-  // Check each lab's containers to see if any have a matching lab path
-  for (const labName in inspectData) {
-    const containers = inspectData[labName];
-    if (Array.isArray(containers) && containers.length > 0) {
-      // Check the first container's lab path (all containers in a lab share the same path)
-      const container = containers[0];
-      const containerLabPath = container.Labels["clab-topo-file"];
-      if (containerLabPath === labPath) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
-function resolveLabInfo(
-  node?: ClabLabTreeNode
-): { labPath: string; isViewMode: boolean } | undefined {
-  if (
-    node !== undefined &&
-    node.contextValue !== undefined &&
-    node.contextValue.length > 0 &&
-    (node.contextValue === "containerlabLabDeployed" ||
-      node.contextValue === "containerlabLabDeployedFavorite")
-  ) {
-    return { labPath: node.labPath.absolute, isViewMode: true };
-  }
-
+function resolveLabPath(node?: ClabLabTreeNode): string | undefined {
   if (node !== undefined && node.labPath.absolute.length > 0) {
-    // Check if this lab is actually running
-    const isRunning = isLabRunning(node.labPath.absolute);
-    return { labPath: node.labPath.absolute, isViewMode: isRunning };
+    return node.labPath.absolute;
   }
 
   const editor = vscode.window.activeTextEditor;
   const topoFileRegex = /\.clab\.(yaml|yml)$/;
   if (editor && topoFileRegex.test(editor.document.uri.fsPath)) {
-    // Check if this lab is actually running
-    const isRunning = isLabRunning(editor.document.uri.fsPath);
-    return { labPath: editor.document.uri.fsPath, isViewMode: isRunning };
+    return editor.document.uri.fsPath;
   }
 
   vscode.window.showErrorMessage("No lab node or topology file selected");
@@ -150,11 +116,10 @@ export async function graphTopoviewer(node?: ClabLabTreeNode, context?: vscode.E
   // Get node if not provided
   node = await getSelectedLabNode(node);
 
-  const labInfo = resolveLabInfo(node);
-  if (!labInfo) {
+  const labPath = resolveLabPath(node);
+  if (labPath === undefined) {
     return;
   }
-  const { labPath, isViewMode } = labInfo;
 
   if (!context) {
     vscode.window.showErrorMessage("Extension context not available");
@@ -166,9 +131,10 @@ export async function graphTopoviewer(node?: ClabLabTreeNode, context?: vscode.E
     node?.name ??
     (labPath ? path.basename(labPath).replace(/\.clab\.(yml|yaml)$/i, "") : "Unknown Lab");
 
-  // Use the provider to create/get the viewer
+  // Use the provider to create/get the viewer. The viewer is always editable;
+  // it attaches runtime data on its own when the lab is deployed.
   const provider = ReactTopoViewerProvider.getInstance(context);
-  const viewer = await provider.openViewer(labPath, labName, isViewMode);
+  const viewer = await provider.openViewer(labPath, labName);
 
   currentTopoViewer = viewer;
   viewer.requestFitViewport();

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -12,8 +12,9 @@ export type {
   CommandFailureHandler
 } from "./base";
 
-// Lifecycle commands (deploy, destroy, redeploy, save)
+// Lifecycle commands (deploy, destroy, redeploy, apply, save)
 export {
+  apply,
   deploy,
   deployCleanup,
   deploySpecificFile,

--- a/src/commands/lifecycle/index.ts
+++ b/src/commands/lifecycle/index.ts
@@ -2,6 +2,7 @@
  * Lifecycle commands - deploy, destroy, redeploy, save
  */
 
+export { apply } from "../apply";
 export { deploy, deployCleanup, deploySpecificFile } from "../deploy";
 export { destroy, destroyCleanup } from "../destroy";
 export { startLab, stopLab, restartLab } from "../labNodeLifecycle";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -373,6 +373,7 @@ function registerCommands(context: vscode.ExtensionContext) {
     ["containerlab.lab.deployPopular", cmd.deployPopularLab],
     ["containerlab.lab.redeploy", cmd.redeploy],
     ["containerlab.lab.redeploy.cleanup", cmd.redeployCleanup],
+    ["containerlab.lab.apply", cmd.apply],
     ["containerlab.lab.destroy", cmd.destroy],
     ["containerlab.lab.destroy.cleanup", cmd.destroyCleanup],
     ["containerlab.lab.start", cmd.startLab],

--- a/src/reactTopoViewer/extension/ReactTopoViewerProvider.ts
+++ b/src/reactTopoViewer/extension/ReactTopoViewerProvider.ts
@@ -8,6 +8,9 @@
  * - Topology data loading (via TopologyHost)
  */
 
+import * as fs from "fs";
+import * as path from "path";
+
 import * as vscode from "vscode";
 
 import { runningLabsProvider } from "../../globals";
@@ -85,8 +88,9 @@ export class ReactTopoViewer {
   public context: vscode.ExtensionContext;
   public lastYamlFilePath: string = "";
   public currentLabName: string = "";
-  public isViewMode: boolean = false;
   public deploymentState: "deployed" | "undeployed" | "unknown" = "unknown";
+  /** Whether the on-disk topology diverged from the deployed runtime (apply pending). */
+  private dirtyState: boolean | undefined;
   private runtimeContainers: HostRuntimeContainer[] = [];
   private lastTopologyEdges: TopoEdge[] = [];
   private watcherManager: WatcherManager;
@@ -233,9 +237,45 @@ export class ReactTopoViewer {
       log.warn(`Failed to check deployment state: ${formatErrorMessage(err)}`);
       this.deploymentState = "unknown";
     }
+    this.dirtyState = this.computeDirtyState();
 
-    if (this.isViewMode) {
+    if (this.isDeployed) {
       this.runtimeContainers = await this.loadRunningLabRuntimeContainers();
+    }
+  }
+
+  /** Whether the lab is running, i.e. runtime data should be attached. */
+  public get isDeployed(): boolean {
+    return this.deploymentState === "deployed";
+  }
+
+  /**
+   * Compare the topology file against the lab state file containerlab writes on
+   * deploy/apply (`clab-<lab>/.state.clab.yaml`, containerlab >= 0.77). A newer
+   * topology file means `containerlab apply` has pending changes. Returns
+   * `undefined` (unknown) when the lab is not running or the state file is
+   * unavailable.
+   */
+  private computeDirtyState(): boolean | undefined {
+    if (this.deploymentState !== "deployed") {
+      return undefined;
+    }
+    const yamlPath = this.lastYamlFilePath;
+    const labName = this.currentLabName;
+    if (!yamlPath || !labName) {
+      return undefined;
+    }
+    try {
+      const stateFilePath = path.join(
+        path.dirname(yamlPath),
+        `clab-${labName}`,
+        ".state.clab.yaml"
+      );
+      const yamlStat = fs.statSync(yamlPath);
+      const stateStat = fs.statSync(stateFilePath);
+      return yamlStat.mtimeMs > stateStat.mtimeMs;
+    } catch {
+      return undefined;
     }
   }
 
@@ -245,11 +285,9 @@ export class ReactTopoViewer {
   public async createWebviewPanel(
     context: vscode.ExtensionContext,
     fileUri: vscode.Uri,
-    labName: string,
-    viewMode: boolean = false
+    labName: string
   ): Promise<void> {
     this.currentLabName = labName;
-    this.isViewMode = viewMode;
 
     if (fileUri.fsPath.length > 0) {
       this.lastYamlFilePath = fileUri.fsPath;
@@ -273,12 +311,14 @@ export class ReactTopoViewer {
 
     await this.initializeLabState(labName);
 
+    // The topology is always editable; runtime data attaches when deployed.
     this.topologyHost = new TopologyHostCore({
       fs: nodeFsAdapter,
       yamlFilePath: this.lastYamlFilePath,
-      mode: this.isViewMode ? "view" : "edit",
+      mode: "edit",
       deploymentState: this.deploymentState,
-      containerDataProvider: this.isViewMode
+      dirty: this.dirtyState,
+      containerDataProvider: this.isDeployed
         ? createRuntimeContainerDataProvider(this.runtimeContainers)
         : undefined,
       setInternalUpdate: (updating: boolean) => this.setInternalUpdate(updating),
@@ -287,7 +327,6 @@ export class ReactTopoViewer {
 
     this.messageRouter = new MessageRouter({
       yamlFilePath: this.lastYamlFilePath,
-      isViewMode: this.isViewMode,
       splitViewManager: this.splitViewManager,
       topologyHost: this.topologyHost,
       setInternalUpdate: (updating: boolean) => this.setInternalUpdate(updating),
@@ -369,21 +408,18 @@ export class ReactTopoViewer {
     try {
       // Update internal state
       this.deploymentState = newDeploymentState;
-      this.isViewMode = newDeploymentState === "deployed";
+      // Deploy/apply/redeploy refresh the containerlab state file, so the mtime
+      // comparison reflects the new baseline right after a lifecycle command.
+      this.dirtyState = this.computeDirtyState();
 
-      // Update message router context
-      if (this.messageRouter) {
-        this.messageRouter.updateContext({ isViewMode: this.isViewMode });
-      }
-
-      // Reload running lab data if switching to view mode
-      this.runtimeContainers = this.isViewMode ? await this.loadRunningLabRuntimeContainers() : [];
+      // Reload running lab data when the lab is (still) deployed
+      this.runtimeContainers = this.isDeployed ? await this.loadRunningLabRuntimeContainers() : [];
 
       if (this.topologyHost) {
         this.topologyHost.updateContext({
-          mode: this.isViewMode ? "view" : "edit",
           deploymentState: this.deploymentState,
-          containerDataProvider: this.isViewMode
+          dirty: this.dirtyState,
+          containerDataProvider: this.isDeployed
             ? createRuntimeContainerDataProvider(this.runtimeContainers)
             : undefined
         });
@@ -415,17 +451,16 @@ export class ReactTopoViewer {
       return;
     }
 
-    const mode = this.isViewMode ? "viewer" : "editor";
-
     this.currentPanel.webview.postMessage({
       type: MSG_TOPO_MODE_CHANGE,
       data: {
-        mode,
-        deploymentState: this.deploymentState
+        mode: "editor",
+        deploymentState: this.deploymentState,
+        ...(this.dirtyState !== undefined ? { dirty: this.dirtyState } : {})
       }
     });
 
-    log.info(`[ReactTopoViewer] Mode changed to: ${mode}`);
+    log.info(`[ReactTopoViewer] Deployment state changed to: ${this.deploymentState}`);
   }
 
   /**
@@ -437,7 +472,7 @@ export class ReactTopoViewer {
   public async refreshLinkStatesFromInspect(
     labsData?: Record<string, ClabLabTreeNode>
   ): Promise<void> {
-    if (!this.currentPanel || !this.isViewMode) {
+    if (!this.currentPanel || !this.isDeployed) {
       return;
     }
 
@@ -503,11 +538,7 @@ export class ReactTopoViewerProvider {
   /**
    * Open or create a React TopoViewer for the given lab
    */
-  public async openViewer(
-    labPath: string,
-    labName: string,
-    isViewMode: boolean
-  ): Promise<ReactTopoViewer> {
+  public async openViewer(labPath: string, labName: string): Promise<ReactTopoViewer> {
     // Check for existing viewer
     const existingViewer = this.viewers.get(labPath);
     if (existingViewer?.currentPanel) {
@@ -520,8 +551,7 @@ export class ReactTopoViewerProvider {
     await viewer.createWebviewPanel(
       this.context,
       labPath ? vscode.Uri.file(labPath) : vscode.Uri.parse(""),
-      labName,
-      isViewMode
+      labName
     );
 
     // Track the viewer

--- a/src/reactTopoViewer/extension/panel/MessageRouter.ts
+++ b/src/reactTopoViewer/extension/panel/MessageRouter.ts
@@ -71,7 +71,6 @@ function asStringArray(value: unknown): string[] {
  */
 export interface MessageRouterContext {
   yamlFilePath: string;
-  isViewMode: boolean;
   splitViewManager: SplitViewManager;
   topologyHost?: TopologyHost;
   setInternalUpdate: (updating: boolean) => void;

--- a/src/reactTopoViewer/extension/services/LabLifecycleService.ts
+++ b/src/reactTopoViewer/extension/services/LabLifecycleService.ts
@@ -60,6 +60,12 @@ const LAB_ACTIONS = {
     errorMsg: "Error redeploying lab with cleanup",
     noLabPath: "No lab path provided for redeploy with cleanup"
   },
+  applyLab: {
+    command: "containerlab.lab.apply",
+    resultMsg: "Lab apply initiated",
+    errorMsg: "Error applying lab topology",
+    noLabPath: "No lab path provided for apply"
+  },
   startLab: {
     command: "containerlab.lab.start",
     resultMsg: "Lab node start initiated",

--- a/src/treeView/runningLabsProvider.ts
+++ b/src/treeView/runningLabsProvider.ts
@@ -266,7 +266,7 @@ export class RunningLabTreeDataProvider implements vscode.TreeDataProvider<
    */
   private async refreshTopoViewerIfOpen(): Promise<void> {
     const viewer = getCurrentTopoViewer();
-    if (viewer?.currentPanel && viewer.isViewMode) {
+    if (viewer?.currentPanel && viewer.isDeployed) {
       try {
         const labsForViewer = this.getLabsSnapshotForViewer();
         await viewer.refreshLinkStatesFromInspect(labsForViewer);

--- a/test/unit/webviews/messageRouter.topologyHost.test.ts
+++ b/test/unit/webviews/messageRouter.topologyHost.test.ts
@@ -65,7 +65,6 @@ describe("MessageRouter topology-host command parsing", () => {
 
       const router = new MessageRouter({
         yamlFilePath: "/tmp/test.clab.yml",
-        isViewMode: false,
         splitViewManager: { toggleSplitView: async () => false } as never,
         topologyHost: { applyCommand } as never,
         setInternalUpdate: () => {}


### PR DESCRIPTION
## Summary

Companion to srl-labs/clab-ui#28 — adds the containerlab 0.77 `apply` lifecycle to the extension and removes the running/undeployed split from the TopoViewer.

- New `containerlab.lab.apply` command (`ctrl+alt+a`), available from the command palette, editor title/run and context menus, and the explorer; wired into the TopoViewer lifecycle handling so the webview Apply button runs `containerlab apply -t <topo>`.
- Topology sync state is computed by comparing the topo file mtime against the lab state file (`clab-<lab>/.state.clab.yaml`, written by containerlab >= 0.77 on deploy and apply) and forwarded to the webview, driving the Apply button's dirty badge.
- The TopoViewer now always opens in edit mode; runtime data (containers, link stats, node states) attaches whenever the lab is deployed and switches live after deploy/apply/destroy. The `isViewMode` plumbing is replaced by deployment-state checks.

Requires containerlab >= 0.77.

## Test evidence

- `npx tsc --noEmit` clean, `npm run lint` at baseline
- `npm run package` builds the VSIX successfully (validated against a local @srl-labs/clab-ui 0.2.0 build)
- `npm test` compile failure is pre-existing on main (tsconfig module/bundler mismatch in this environment)

Version bumped to 0.26.0. Depends on @srl-labs/clab-ui 0.2.0 being published (srl-labs/clab-ui#28).