### PR TITLE
chore: adopt clab-ui 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Change Log
 
+## [0.26.0] - 2026-07-07
+
+- Deploy/runtime:
+  - Added `containerlab apply` support from TopoViewer so topology changes can be applied to running labs without a full redeploy workflow.
+- TopoViewer/editor:
+  - Free-text annotations can now be edited directly on the canvas, including inline formatting controls and markdown preview while editing.
+  - Text, shape, group, and traffic annotation edits apply immediately instead of requiring a separate visual-apply step.
+  - Dragging nodes and annotations from the palette now shows a canvas-style preview before dropping.
+  - Improved dirty-state detection so Apply is only needed when the topology content actually changed.
+  - Better edit-mode behavior for deployed labs, including text annotation double-click handling after unlocking.
+- SVG and Grafana export:
+  - Reworked SVG export so exported topology geometry matches the canvas much more closely.
+  - Improved rendering of node icons, endpoint bubbles, links, labels, free-shape annotations, and free-text annotations in exports.
+- Explorer/runtime:
+  - Container logs remain available for exited containers.
+
 ## [0.25.0] - 2026-04-26
 
 - TopoViewer/editor:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.26.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@srl-labs/clab-ui": "0.2.0",
+        "@srl-labs/clab-ui": "0.3.0",
         "@types/chai": "^5.2.3",
         "@types/dockerode": "^4.0.1",
         "@types/mocha": "^10.0.10",
@@ -389,29 +389,6 @@
       "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/@base-ui/utils": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.2.8.tgz",
-      "integrity": "sha512-jvOi+c+ftGlGotNcKnzPVg2IhCaDTB6/6R3JeqdjdXktuAJi3wKH9T7+svuaKh1mmfVU11UWzUZVH74JDfi/wQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.29.2",
-        "@floating-ui/utils": "^0.2.11",
-        "reselect": "^5.1.1",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^17 || ^18 || ^19",
-        "react": "^17 || ^18 || ^19",
-        "react-dom": "^17 || ^18 || ^19"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
@@ -1024,13 +1001,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/@floating-ui/utils": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
-      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@fontsource/roboto": {
       "version": "5.2.10",
@@ -1666,46 +1636,6 @@
       },
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@mui/x-tree-view": {
-      "version": "8.28.3",
-      "resolved": "https://registry.npmjs.org/@mui/x-tree-view/-/x-tree-view-8.28.3.tgz",
-      "integrity": "sha512-VRsT44UlJJQKgxjddoP/QWSK9sMxICRaQOYDRU5o35fC5fc6/5uwFk/Xh5bEkYbMVin49U/KiaOi+OayO9sPKg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "@base-ui/utils": "^0.2.3",
-        "@mui/utils": "^7.3.5",
-        "@mui/x-internals": "8.26.0",
-        "@types/react-transition-group": "^4.4.12",
-        "clsx": "^2.1.1",
-        "prop-types": "^15.8.1",
-        "react-transition-group": "^4.4.5"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.9.0",
-        "@emotion/styled": "^11.8.1",
-        "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
-        "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        }
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -2502,7 +2432,9 @@
       }
     },
     "node_modules/@srl-labs/clab-ui": {
-      "version": "0.2.0",
+      "version": "0.3.0",
+      "resolved": "https://npm.pkg.github.com/download/@srl-labs/clab-ui/0.3.0/90605c1a6049e8f7f237f1b41e88cf3efe3ce38b",
+      "integrity": "sha512-x3xoi5xIF4V17pgaPsGvoEgXYhAie6z/WodK7N0ErxGnRAwbDdTJm/4LHs6KFfhS0QFXTg1TCa2KpTfCMv+j5g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2512,7 +2444,6 @@
         "@mui/icons-material": "^7.3.10",
         "@mui/material": "^7.3.10",
         "@mui/x-charts": "^8.28.2",
-        "@mui/x-tree-view": "^8.28.3",
         "@xyflow/react": "^12.10.2",
         "ajv": "^8.18.0",
         "d3-force": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1058,7 +1058,7 @@
     "uuid": "14.0.0"
   },
   "devDependencies": {
-    "@srl-labs/clab-ui": "0.2.0",
+    "@srl-labs/clab-ui": "0.3.0",
     "@types/chai": "^5.2.3",
     "@types/dockerode": "^4.0.1",
     "@types/mocha": "^10.0.10",


### PR DESCRIPTION
- Bump the published `@srl-labs/clab-ui` dependency to `0.3.0`.
- Update the extension changelog with the user-facing release notes for `containerlab apply`, TopoViewer editing, export fidelity, and exited-container logs.
- Refresh the lockfile so packaged webviews consume the published package artifact.