### PR TITLE
fix: capture veth-stitch interfaces

### DIFF
--- a/src/commands/capture.ts
+++ b/src/commands/capture.ts
@@ -5,6 +5,7 @@ import * as utils from "../utils";
 import type { ClabInterfaceTreeNode } from "../treeView/common";
 import { genPacketflixURI, getHostname, setSessionHostname } from "../utils/packetflix";
 import type { ImagePullPolicy } from "../utils/consts";
+import { captureScopeKey } from "../utils/packetflixTarget";
 import { getWiresharkVncWebviewHtml } from "../webviews/wiresharkVnc/wiresharkVncWebviewHtml";
 import {
   DEFAULT_WIRESHARK_VNC_DOCKER_IMAGE,
@@ -55,16 +56,17 @@ async function buildPacketflixUri(
   const selected = allSelectedNodes && allSelectedNodes.length > 0 ? allSelectedNodes : [node];
 
   if (selected.length > 1) {
-    const uniqueContainers = new Set(selected.map((i) => i.parentName));
-    if (uniqueContainers.size > 1) {
+    const captureGroups = Map.groupBy(selected, captureScopeKey);
+    if (captureGroups.size > 1) {
       outputChannel.debug(
-        "Edgeshark multi selection => multiple containers => launching individually"
+        "Edgeshark multi selection => multiple capture namespaces => launching separately"
       );
-      for (const nd of selected) {
+      for (const group of captureGroups.values()) {
+        const nd = group[0];
         if (forVNC === true) {
-          await captureEdgesharkVNC(nd);
+          await captureEdgesharkVNC(nd, group);
         } else {
-          await captureInterfaceWithPacketflix(nd);
+          await captureInterfaceWithPacketflix(nd, group);
         }
       }
       return undefined;

--- a/src/services/containerlabInspectFallback.ts
+++ b/src/services/containerlabInspectFallback.ts
@@ -394,10 +394,11 @@ function toInterfaceSnapshot(raw: ClabInspectInterfaceJSON[]): ClabInterfaceSnap
  */
 export function getInterfaceSnapshot(
   _containerShortId: string,
-  containerName: string
+  containerName: string,
+  labPathOverride?: string
 ): ClabInterfaceSnapshot[] {
   // Find the lab path for this container
-  const labPath = findLabPathForContainer(containerName);
+  const labPath = labPathOverride ?? findLabPathForContainer(containerName);
   if (labPath === undefined || labPath.length === 0) {
     console.warn(
       `[containerlabInspectFallback]: Could not find lab path for container ${containerName}`

--- a/src/services/interfaceSnapshots.ts
+++ b/src/services/interfaceSnapshots.ts
@@ -1,0 +1,52 @@
+import type { ClabInterfaceSnapshot, ClabInterfaceSnapshotEntry } from "../types/containerlab";
+
+function interfacesMatch(
+  inspected: ClabInterfaceSnapshotEntry,
+  live: ClabInterfaceSnapshotEntry
+): boolean {
+  if (inspected.name === live.name) {
+    return true;
+  }
+
+  const inspectedNames = new Set([inspected.name, inspected.alias].filter(Boolean));
+  return [live.name, live.alias].some((name) => name !== "" && inspectedNames.has(name));
+}
+
+/**
+ * Prefer `containerlab inspect interfaces` metadata while preserving live
+ * event data such as traffic counters and netem state. Inspect resolves a
+ * topology interface to its host-side tools interface when one exists.
+ */
+export function mergeInterfaceSnapshots(
+  inspectedSnapshots: ClabInterfaceSnapshot[],
+  liveSnapshots: ClabInterfaceSnapshot[]
+): ClabInterfaceSnapshot[] {
+  if (inspectedSnapshots.length === 0) {
+    return liveSnapshots;
+  }
+  if (liveSnapshots.length === 0) {
+    return inspectedSnapshots;
+  }
+
+  return inspectedSnapshots.map((inspectedSnapshot) => {
+    const liveSnapshot =
+      liveSnapshots.find((snapshot) => snapshot.name === inspectedSnapshot.name) ??
+      liveSnapshots[0];
+    const unmatchedLive = new Set(liveSnapshot.interfaces);
+
+    const interfaces = inspectedSnapshot.interfaces.map((inspectedInterface) => {
+      const liveInterface = liveSnapshot.interfaces.find((candidate) =>
+        interfacesMatch(inspectedInterface, candidate)
+      );
+      if (!liveInterface) {
+        return inspectedInterface;
+      }
+
+      unmatchedLive.delete(liveInterface);
+      return { ...liveInterface, ...inspectedInterface };
+    });
+
+    interfaces.push(...unmatchedLive);
+    return { ...liveSnapshot, ...inspectedSnapshot, interfaces };
+  });
+}

--- a/src/treeView/inspector.ts
+++ b/src/treeView/inspector.ts
@@ -4,6 +4,7 @@ import * as events from "../services/containerlabEvents";
 import * as fallback from "../services/containerlabInspectFallback";
 import { outputChannel } from "../globals";
 import type { ClabInterfaceSnapshot } from "../types/containerlab";
+import { mergeInterfaceSnapshots } from "../services/interfaceSnapshots";
 
 import type * as c from "./common";
 
@@ -97,7 +98,25 @@ export function getInterfacesSnapshot(
     // Use fallback's interface fetching via containerlab inspect interfaces
     return fallback.getInterfaceSnapshot(containerShortId, containerName);
   }
-  return events.getInterfaceSnapshot(containerShortId, containerName);
+  const liveSnapshot = events.getInterfaceSnapshot(containerShortId, containerName);
+  const inspectedSnapshot = fallback.getInterfaceSnapshot(
+    containerShortId,
+    containerName,
+    findLabPath(containerName)
+  );
+  return mergeInterfaceSnapshots(inspectedSnapshot, liveSnapshot);
+}
+
+function findLabPath(containerName: string): string | undefined {
+  for (const containers of Object.values(rawInspectData ?? {})) {
+    const container = containers.find((entry) => entry.Names[0] === containerName);
+    if (container) {
+      const labelPath = container.Labels["clab-topo-file"];
+      const metadataPath: unknown = Reflect.get(containers, "topo-file");
+      return labelPath || (typeof metadataPath === "string" ? metadataPath : undefined);
+    }
+  }
+  return undefined;
 }
 
 export function getInterfaceVersion(containerShortId: string): number {

--- a/src/utils/packetflix.ts
+++ b/src/utils/packetflix.ts
@@ -1,4 +1,5 @@
 import * as os from "os";
+import { stat } from "fs/promises";
 
 import * as vscode from "vscode";
 
@@ -6,6 +7,7 @@ import type * as c from "../treeView/common";
 import { outputChannel } from "../globals";
 
 import * as utils from "./utils";
+import { buildPacketflixTarget, isHostCaptureInterface } from "./packetflixTarget";
 
 let sessionHostname = "";
 
@@ -48,7 +50,12 @@ export async function genPacketflixURI(
   const packetflixPort = config.get<number>("capture.packetflixPort", 5001);
 
   const containerStr = encodeURIComponent(
-    `{"network-interfaces":["${node.name}"],"name":"${node.parentName}","type":"docker"}`
+    JSON.stringify(
+      buildPacketflixTarget(
+        selectedNodes,
+        isHostCaptureInterface(node) ? await getHostNetworkNamespaceId() : undefined
+      )
+    )
   );
 
   const uri = `packetflix:ws://${bracketed}:${packetflixPort}/capture?container=${containerStr}&nif=${node.name}`;
@@ -113,16 +120,10 @@ async function captureMultipleEdgeshark(
     `multi-interface edgeshark for container=${base.parentName} ifaces=[${ifNames.join(", ")}]`
   );
 
-  // Type guard: netns property may exist on runtime objects but isn't in the type definition
-  const baseWithNetns = base as c.ClabInterfaceTreeNode & { netns?: number };
-  const netnsVal = baseWithNetns.netns ?? 4026532270;
-  const containerObj = {
-    netns: netnsVal,
-    "network-interfaces": ifNames,
-    name: base.parentName,
-    type: "docker",
-    prefix: ""
-  };
+  const containerObj = buildPacketflixTarget(
+    nodes,
+    isHostCaptureInterface(base) ? await getHostNetworkNamespaceId() : undefined
+  );
 
   const containerStr = encodeURIComponent(JSON.stringify(containerObj));
   const nifParam = encodeURIComponent(ifNames.join("/"));
@@ -140,6 +141,11 @@ async function captureMultipleEdgeshark(
   outputChannel.debug(`multi-edgeShark => ${packetflixUri}`);
 
   return [packetflixUri, bracketed];
+}
+
+async function getHostNetworkNamespaceId(): Promise<number> {
+  const namespace = await stat("/proc/self/ns/net");
+  return namespace.ino;
 }
 
 /**

--- a/src/utils/packetflixTarget.ts
+++ b/src/utils/packetflixTarget.ts
@@ -1,0 +1,55 @@
+import type { ClabInterfaceTreeNode } from "../treeView/common";
+
+const VETH_STITCH_INTERFACE_PREFIX = "clab-s-";
+const FALLBACK_NETNS_ID = 4026532270;
+
+export interface PacketflixTarget {
+  netns?: number;
+  name?: string;
+  type?: string;
+  prefix?: string;
+  "network-interfaces": string[];
+}
+
+export function isHostCaptureInterface(node: ClabInterfaceTreeNode): boolean {
+  return node.name.startsWith(VETH_STITCH_INTERFACE_PREFIX);
+}
+
+export function captureScopeKey(node: ClabInterfaceTreeNode): string {
+  return `${node.parentName}:${isHostCaptureInterface(node) ? "host" : "container"}`;
+}
+
+export function buildPacketflixTarget(
+  nodes: ClabInterfaceTreeNode[],
+  hostNetns?: number
+): PacketflixTarget {
+  const base = nodes[0];
+  const interfaceNames = nodes.map((node) => node.name);
+
+  if (isHostCaptureInterface(base)) {
+    if (hostNetns === undefined) {
+      throw new Error("host network namespace is required for a veth-stitch capture");
+    }
+    return {
+      netns: hostNetns,
+      "network-interfaces": interfaceNames
+    };
+  }
+
+  if (nodes.length === 1) {
+    return {
+      name: base.parentName,
+      type: "docker",
+      "network-interfaces": interfaceNames
+    };
+  }
+
+  const baseWithNetns = base as ClabInterfaceTreeNode & { netns?: number };
+  return {
+    netns: baseWithNetns.netns ?? FALLBACK_NETNS_ID,
+    name: base.parentName,
+    type: "docker",
+    prefix: "",
+    "network-interfaces": interfaceNames
+  };
+}

--- a/test/unit/services/interfaceSnapshots.test.ts
+++ b/test/unit/services/interfaceSnapshots.test.ts
@@ -1,0 +1,63 @@
+/* global describe, it */
+import { expect } from "chai";
+
+import { mergeInterfaceSnapshots } from "../../../src/services/interfaceSnapshots";
+import type {
+  ClabInterfaceSnapshot,
+  ClabInterfaceSnapshotEntry
+} from "../../../src/types/containerlab";
+
+function iface(
+  name: string,
+  alias: string,
+  overrides: Partial<ClabInterfaceSnapshotEntry> = {}
+): ClabInterfaceSnapshotEntry {
+  return {
+    name,
+    alias,
+    type: "veth",
+    state: "up",
+    mac: "02:00:00:00:00:01",
+    mtu: 1500,
+    ifindex: 10,
+    ...overrides
+  };
+}
+
+function snapshot(interfaces: ClabInterfaceSnapshotEntry[]): ClabInterfaceSnapshot[] {
+  return [{ name: "clab-demo-sros1", interfaces }];
+}
+
+describe("interface snapshot merging", () => {
+  it("uses the inspected host-side stitch interface and keeps live statistics", () => {
+    const inspected = snapshot([iface("clab-s-12345678", "1/1/c1/1", { ifindex: 42 })]);
+    const live = snapshot([
+      iface("eth1", "1/1/c1/1", {
+        rxBps: 1000,
+        txBps: 2000,
+        netemLoss: "5%"
+      })
+    ]);
+
+    const merged = mergeInterfaceSnapshots(inspected, live)[0].interfaces;
+
+    expect(merged).to.have.length(1);
+    expect(merged[0]).to.include({
+      name: "clab-s-12345678",
+      alias: "1/1/c1/1",
+      ifindex: 42,
+      rxBps: 1000,
+      txBps: 2000,
+      netemLoss: "5%"
+    });
+  });
+
+  it("retains live interfaces that are not present in a cached inspection", () => {
+    const inspected = snapshot([iface("eth1", "e1-1")]);
+    const live = snapshot([iface("eth1", "e1-1"), iface("eth2", "e1-2")]);
+
+    const merged = mergeInterfaceSnapshots(inspected, live)[0].interfaces;
+
+    expect(merged.map((entry) => entry.name)).to.deep.equal(["eth1", "eth2"]);
+  });
+});

--- a/test/unit/utils/packetflixTarget.test.ts
+++ b/test/unit/utils/packetflixTarget.test.ts
@@ -1,0 +1,42 @@
+/* global describe, it */
+import { expect } from "chai";
+
+import type { ClabInterfaceTreeNode } from "../../../src/treeView/common";
+import {
+  buildPacketflixTarget,
+  captureScopeKey,
+  isHostCaptureInterface
+} from "../../../src/utils/packetflixTarget";
+
+function interfaceNode(name: string, parentName = "clab-demo-sros1"): ClabInterfaceTreeNode {
+  return { name, parentName } as unknown as ClabInterfaceTreeNode;
+}
+
+describe("Packetflix capture targets", () => {
+  it("targets the host network namespace for a veth-stitch interface", () => {
+    const node = interfaceNode("clab-s-12345678");
+
+    expect(isHostCaptureInterface(node)).to.equal(true);
+    expect(buildPacketflixTarget([node], 4026531840)).to.deep.equal({
+      netns: 4026531840,
+      "network-interfaces": ["clab-s-12345678"]
+    });
+  });
+
+  it("keeps ordinary interfaces scoped to their Docker container", () => {
+    const node = interfaceNode("eth1");
+
+    expect(buildPacketflixTarget([node])).to.deep.equal({
+      name: "clab-demo-sros1",
+      type: "docker",
+      "network-interfaces": ["eth1"]
+    });
+  });
+
+  it("separates host and container interfaces into different capture scopes", () => {
+    const host = interfaceNode("clab-s-12345678");
+    const container = interfaceNode("eth1");
+
+    expect(captureScopeKey(host)).not.to.equal(captureScopeKey(container));
+  });
+});


### PR DESCRIPTION
## Summary

- reconcile event-backed interface snapshots with `containerlab inspect interfaces`
- capture `clab-s-*` stitch peers through the host network namespace
- preserve container-scoped capture for regular interfaces and group mixed-scope selections correctly

## Why

The event-backed interface tree bypassed `containerlab inspect interfaces`, so it retained the node-side interface instead of containerlab's host-side stitch peer. Packetflix targets were also always generated for the node container, while the stitch peer carrying the wire traffic lives in the host network namespace.

Companion API-server fix: https://github.com/srl-labs/clab-api-server/pull/147

Closes #609.

Related to https://github.com/srl-labs/containerlab/pull/3270.

## Testing

- `npm run lint`
- `npm test` — 94 passing
- `npm run build`
