### PR TITLE
Don't filter out the veth-stitch side interfaces

### DIFF
--- a/src/commands/impairments.ts
+++ b/src/commands/impairments.ts
@@ -41,7 +41,9 @@ export async function setImpairment(
   if (impairmentFlag === "") {
     return;
   }
-  const cmd = `${containerlabBinaryPath} tools netem set --node ${node.parentName} --interface ${node.name} ${impairmentFlag}`;
+
+  const netemInterface = node.name.startsWith("clab-s-") && node.alias ? node.alias : node.name;
+  const cmd = `${containerlabBinaryPath} tools netem set --node ${node.parentName} --interface ${netemInterface} ${impairmentFlag}`;
   const msg = `set link impairment to ${JSON.stringify(impairment)} for ${node.name} on ${node.parentName}.`;
   vscode.window.showInformationMessage(`Attempting to ${msg}`);
 

--- a/src/services/containerlabEvents.ts
+++ b/src/services/containerlabEvents.ts
@@ -1128,7 +1128,8 @@ function applyInterfaceEvent(event: ContainerlabEvent): void {
     return;
   }
 
-  if (ifaceName.startsWith("clab-")) {
+  // allow the veth-stitch interfaces to live
+  if (ifaceName.startsWith("clab-") && !ifaceName.startsWith("clab-s-")) {
     removeInterfaceRecord(containerId, ifaceName);
     return;
   }

--- a/src/utils/packetflix.ts
+++ b/src/utils/packetflix.ts
@@ -8,6 +8,12 @@ import { outputChannel } from "../globals";
 import * as utils from "./utils";
 
 let sessionHostname = "";
+const HOST_NETNS_INTERFACE_PREFIX = "clab-s-";
+const HOST_NETNS_CONTAINER_NAME = "systemd(1)";
+
+function isHostNetnsInterface(interfaceName: string): boolean {
+  return interfaceName.startsWith(HOST_NETNS_INTERFACE_PREFIX);
+}
 
 /**
  * Generate a packetflix URI for one or more interfaces. Assumes all nodes belong
@@ -48,7 +54,9 @@ export async function genPacketflixURI(
   const packetflixPort = config.get<number>("capture.packetflixPort", 5001);
 
   const containerStr = encodeURIComponent(
-    `{"network-interfaces":["${node.name}"],"name":"${node.parentName}","type":"docker"}`
+    isHostNetnsInterface(node.name)
+      ? `{"network-interfaces":["${node.name}"],"name":"${HOST_NETNS_CONTAINER_NAME}","prefix":""}`
+      : `{"network-interfaces":["${node.name}"],"name":"${node.parentName}","type":"docker"}`
   );
 
   const uri = `packetflix:ws://${bracketed}:${packetflixPort}/capture?container=${containerStr}&nif=${node.name}`;
@@ -116,13 +124,19 @@ async function captureMultipleEdgeshark(
   // Type guard: netns property may exist on runtime objects but isn't in the type definition
   const baseWithNetns = base as c.ClabInterfaceTreeNode & { netns?: number };
   const netnsVal = baseWithNetns.netns ?? 4026532270;
-  const containerObj = {
-    netns: netnsVal,
-    "network-interfaces": ifNames,
-    name: base.parentName,
-    type: "docker",
-    prefix: ""
-  };
+  const containerObj = isHostNetnsInterface(base.name)
+    ? {
+        "network-interfaces": ifNames,
+        name: HOST_NETNS_CONTAINER_NAME,
+        prefix: ""
+      }
+    : {
+        netns: netnsVal,
+        "network-interfaces": ifNames,
+        name: base.parentName,
+        type: "docker",
+        prefix: ""
+      };
 
   const containerStr = encodeURIComponent(JSON.stringify(containerObj));
   const nifParam = encodeURIComponent(ifNames.join("/"));


### PR DESCRIPTION
Rest of the handling will be solved in containerlab, just one minor part here where we filtered out the `clab-s-` host-ns stitching interfaces in the events processing.

Closes https://github.com/srl-labs/vscode-containerlab/issues/609.